### PR TITLE
fix(seo): keep taxonomy sitemap dates valid

### DIFF
--- a/src/app/__tests__/sitemap-frozen.test.ts
+++ b/src/app/__tests__/sitemap-frozen.test.ts
@@ -30,6 +30,13 @@ describe("sitemap", () => {
     expect(sitemapPaths).toEqual([...PUBLIC_ROUTE_PATHS].sort());
   });
 
+  it("emits a valid last-modified date for every URL", () => {
+    for (const entry of sitemap()) {
+      expect(entry.lastModified, entry.url).toBeInstanceOf(Date);
+      expect(Number.isFinite((entry.lastModified as Date).getTime()), entry.url).toBe(true);
+    }
+  });
+
   it("includes every frozen detail page (TRACKED source preserves indexability)", () => {
     const entries = sitemap();
     const urls = new Set(entries.map((entry) => entry.url));

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -234,7 +234,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const taxonomyPages: MetadataRoute.Sitemap = ALL_STABLECOIN_TAXONOMY_PAGES.map((page) => ({
     url: `${SITE_URL}${page.href}`,
-    lastModified: lastEdited(page.href),
+    lastModified: lastEdited(page.href, "/stablecoins/"),
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));


### PR DESCRIPTION
Fixes the Pages production build failure in run 31940445289 by falling unmapped stablecoin taxonomy routes back to the stablecoins hub Git date and asserting every sitemap entry has a finite Date. Validated with the focused 14-test sitemap suite, a 1,112-entry date audit, npm run build, npm run seo:check across 1,248 HTML pages, npm run check:pr -- --base=origin/main (19 files / 362 tests), and the pre-push artifact gate. Worker deployment run 31940514319 completed separately.