### PR TITLE
fix(deploy): restore post-deploy acceptance

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -204,11 +204,11 @@ jobs:
           node --input-type=module <<'NODE'
           import { appendFileSync } from "node:fs";
 
-          import { fetchJsonProbe, collectWorkerHttpProbes } from "./scripts/lib/worker-http-probes.mjs";
+          import { fetchJsonProbe, collectWorkerHttpProbes } from "./scripts/lib/worker-http-probes.mts";
           import {
             selectPostDeployProbes,
             summarizePostDeployAcceptance,
-          } from "./scripts/lib/post-deploy-acceptance.mjs";
+          } from "./scripts/lib/post-deploy-acceptance.mts";
 
           const probes = selectPostDeployProbes({
             pagesDeployed: process.env.PAGES_DEPLOYED === "true",

--- a/scripts/__tests__/ci-workflow-scope.test.ts
+++ b/scripts/__tests__/ci-workflow-scope.test.ts
@@ -54,6 +54,8 @@ describe("CI workflow scope", () => {
     expect(acceptanceStep?.name).toContain("read-only");
     expect(acceptanceStep?.run).toContain("selectPostDeployProbes");
     expect(acceptanceStep?.run).toContain("collectWorkerHttpProbes");
+    expect(acceptanceStep?.run).toContain('from "./scripts/lib/worker-http-probes.mts"');
+    expect(acceptanceStep?.run).toContain('from "./scripts/lib/post-deploy-acceptance.mts"');
     expect(acceptanceStep?.run).toContain("Outcome:");
     expect(acceptanceStep?.run).toContain("automatic rollback");
     expect(acceptanceStep?.run).not.toContain("wrangler");

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -1,6 +1,6 @@
 {
   "api-reference": {
-    "dateModified": "2026-08-16T15:47:49+02:00",
+    "dateModified": "2026-08-16T21:19:16+02:00",
     "dateCreated": "2026-02-23T15:28:17+01:00"
   },
   "architecture": {
@@ -16,7 +16,7 @@
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "worker-and-api-limits": {
-    "dateModified": "2026-08-16T17:21:18+02:00",
+    "dateModified": "2026-08-16T21:19:16+02:00",
     "dateCreated": "2026-03-01T13:33:58+01:00"
   },
   "classification": {


### PR DESCRIPTION
## Summary

- point the deployment acceptance job at the typed `.mts` helper modules
- add workflow regression assertions for both runtime imports
- refresh commit-derived docs metadata

## Verification

- exact read-only production acceptance command: Pages 200, Worker 200/healthy
- `npm run check:pr -- --base=origin/main` (351 tests)
- `npm run check:generated-artifacts`
- `git diff --check`