### PR TITLE
Issue triage: kUSD jurisdiction, WUSD record correction, reUSD Solana, maintenance CI

### DIFF
--- a/.github/workflows/agent-maintenance-candidates.yml
+++ b/.github/workflows/agent-maintenance-candidates.yml
@@ -100,6 +100,12 @@ jobs:
             gh issue create --title "Agent maintenance candidates" --body-file "$body"
           fi
 
+          # Fail the run, not just the issue body. A ::warning kept this job
+          # green through three consecutive broken runs (2026-08-03, 08-10,
+          # 08-17) while PHAROS_API_KEY was missing, so the only signal was
+          # buried in an issue nobody had reason to reopen. The issue is
+          # written first, so a red run still leaves the diagnosis behind.
           if [ "$ANNOTATION_STATUS" != 0 ] || [ "$SUMMARY_STATUS" != 0 ] || [ "$DIGEST_STATUS" != 0 ]; then
-            echo "::warning title=Candidate generation incomplete::See the maintenance issue for command status and available output."
+            echo "::error title=Candidate generation incomplete::See the maintenance issue for command status and available output."
+            exit 1
           fi

--- a/data/ai-summaries.json
+++ b/data/ai-summaries.json
@@ -684,12 +684,30 @@
     "factsAsOf": "2026-08-05"
   },
   "wusd-worldwide": {
-    "title": "Enterprise Rails, Empty Station",
-    "text": "WSPN's white-label dollar pairs conservative T-bill claims with a failing grade and thin DEX liquidity that betrays missing on-chain demand.\n\nWSPN's Worldwide USD pitches a conservative reserve — {{term:treasury}}T-bills{{/term}} and cash with a Basel III-inspired 6% liquidity buffer — yet carries an F safety grade, because v9 scores evidence and market structure rather than brochures: no current reserve composition is on file for the backing pillar, and economic control fails on effectively unbounded mint authority. The peg itself holds clean and rarely strays from the calm end of the stress scale, but liquidity is the soft spot: the DEX float across Ethereum, Polygon, and Viction is too thin to absorb size, and a couple of shallow sub-200-bps wobbles suggest the peg holds because almost nothing tests it. The BVI domicile with FinCEN MSB registration is regulatory limbo: enough paperwork to look legitimate, not enough to satisfy institutional compliance departments shopping for USDC alternatives. WUSD's white-label infrastructure for enterprise stablecoin issuance is the real product pitch, but a payments network needs volume, and volume needs liquidity that isn't here yet — and the {{term:custody}}custody{{/term}} story alone won't fix that.",
-    "updatedAt": "2026-08-05",
+    "title": "The Exit Toll",
+    "text": "A dollar token that lost every venue it traded on, then charged a hundred of itself to leave the one still standing.\n\nWSPN's Worldwide USD shed roughly 94% of its circulating supply between 2026-07-21 and mid-August — 9.99M down to 0.61M, with two burns on 07-29 and 08-01 doing most of the work — and no issuer statement has accompanied the contraction. The centralized exits closed in the same window: MEXC delisted on 07-25, Bitget dropped WUSD/USDT on 07-31, and Coins.ph, the flagship retail pair, left on 08-04 with the tidy explanation that WUSD was \"no longer able to adhere to our listing standards.\" What remains is a single Viction pool quoting around $0.95 whose ~$96k headline reserve absorbs roughly $490 before it moves 2%, which is why Pharos now publishes no price at all rather than a number nothing trades at. Direct {{term:redemption}}redemption{{/term}} still functions, but only through corporate accounts that qualified businesses must apply and be verified for — so a holder without a WSPN relationship is routed to a secondary market that no longer exists. The detail worth pausing on sits on Viction, where the VRC25 deployment levies a flat 100 WUSD on token calls: amount-independent, verified on-chain, and charged on approve() as well as transfer(), meaning a wallet must hold $100 of a dollar token before it can authorise a swap of any size. The F grade was already on file before any of this happened; the reserve brochure was never the binding constraint.",
+    "updatedAt": "2026-08-19",
     "authoredBy": "ai",
-    "model": "claude-fable-5",
-    "factsAsOf": "2026-08-05"
+    "model": "claude-opus-5",
+    "factsAsOf": "2026-08-19",
+    "sources": [
+      {
+        "label": "DefiLlama: WUSD circulating supply history (stablecoin 234)",
+        "url": "https://defillama.com/stablecoin/worldwide-usd"
+      },
+      {
+        "label": "Coins.ph: WUSD delisting notice, 2026-08-04",
+        "url": "https://support.coins.ph/hc/en-us/articles/60655699647641"
+      },
+      {
+        "label": "Bitget: notice of delisting 6 spot trading pairs, 2026-07-31",
+        "url": "https://www.bitget.com/support/articles/12560603890084"
+      },
+      {
+        "label": "Viction VRC25 issuer registry entry for WUSD (100 WUSD fee)",
+        "url": "https://issuer.viction.xyz/token/0xBA73E59F11597c1c13B0D9114688Efb6A6D430F6"
+      }
+    ]
   },
   "frxusd-frax": {
     "title": "Frax's Clean Slate",

--- a/docs/dex-liquidity.md
+++ b/docs/dex-liquidity.md
@@ -176,6 +176,14 @@ For direct APIs, balance health is no longer uniformly neutral. Balancer, Raydiu
 - CryptoSwap pools: correctly classified via `registryId`
 - DL Raydium pools: classified from `poolMeta` (Concentrated -> `raydium-clmm`) since v6.0, because DeFiLlama ships every Raydium pool under the `raydium-amm` project slug; this lets the DL row and its direct-API CLMM twin share one pool-shape family and deduplicate instead of double-counting
 
+### Known Uncovered Venues
+
+Venues that qualify for the score on the criteria above but that no configured provider indexes. Listed so a coverage gap is a recorded decision rather than a silent omission.
+
+| Venue | Chain | Why uncovered | Revisit trigger |
+| --- | --- | --- | --- |
+| Jupiter Lend DEX (`jupiter-lend-dex`) | Solana | A concentrated-liquidity AMM on Jupiter's shared liquidity layer, distinct from the `jupiter-lend` lending protocol and classed `Dexs` by DefiLlama. DefiLlama Yields ships no rows for it, and GeckoTerminal and DexScreener do not list it, so neither the `dl` lane nor discovery can see it. Jupiter publishes no REST endpoint — `developers.jup.ag/docs/lend/dex/api.md` is an explicit placeholder — so ingesting it means `getProgramAccounts` plus borsh decoding at IDL-derived offsets inside the source-stage cron, reopening the Solana on-chain lane that v6.0 retired and adding an RPC dependency inside the 6-connection budget. Protocol-wide TVL is ~$7.0M, so present score impact is small. | DefiLlama Yields adding `jupiter-lend-dex` pools, or Jupiter shipping the promised REST endpoints. Either collapses this to a cheap change. Raised as #880. |
+
 ### CoinGecko Onchain Integration
 
 CoinGecko Onchain is a discovery-stage source rather than a direct source-stage fetch. Its outputs are written into `dex_pool_staging` and later merged by `sync-dex-liquidity-stage` if the rows are fresh. Pool parsing, fee-tier classification, balance-ratio inference, and locked-liquidity parsing are shared between discovery and liquidity through `worker/src/cron/dex-liquidity/coingecko-onchain-shared.ts`. CoinGecko Onchain and GeckoTerminal token crawls now read multiple bounded pages (`3 x 20` rows max) before declaring discovery exhausted, which reduces false partial-coverage outcomes on fragmented assets.

--- a/scripts/maintenance/build-annotation-candidates.ts
+++ b/scripts/maintenance/build-annotation-candidates.ts
@@ -10,9 +10,11 @@
  * Promotion to `shared/data/annotations/curated-annotations.ts` is always
  * editorial — this producer never writes there.
  *
- * Failure mode: source-by-source. If the worker endpoint is unreachable,
- * the producer emits a `<!-- source unreachable -->` note for that
- * source and keeps going so repo-local sources still surface.
+ * Failure mode: source-by-source. If the worker endpoint is unreachable —
+ * or `PHAROS_API_KEY` is unset, which is the same thing from the queue's
+ * point of view — the producer emits a note for that source and keeps
+ * going so the repo-local sources still surface. It exits non-zero only
+ * when it cannot write the queue at all.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -30,6 +32,13 @@ const ROOT = process.cwd();
 const OUTPUT_PATH = resolve(ROOT, "agents/annotation-candidates.md");
 const API_BASE_URL = process.env.PHAROS_API_BASE?.trim() || DEFAULT_MAINTENANCE_API_BASE_URL;
 const API_KEY = process.env.PHAROS_API_KEY;
+
+// Named so the queue's source notes say which of the two failures happened.
+// An unset credential and an unreachable worker both degrade to "skipped",
+// but only one of them is fixed by adding a secret.
+const TAPE_SKIP_REASON = API_KEY?.trim()
+  ? `unreachable at ${API_BASE_URL}`
+  : "unavailable: PHAROS_API_KEY is not set";
 const DEFAULT_LOOKBACK_DAYS = 7;
 const LAUNCH_LOOKBACK_DAYS = 30;
 const FETCH_TIMEOUT_MS = 6000;
@@ -87,7 +96,17 @@ interface TapeEventLite {
 }
 
 async function fetchTapeEvents(classFilter: string, sinceMs: number): Promise<TapeEventLite[] | null> {
-  const request = buildMaintenanceApiRequest(API_PATHS.events(), API_KEY, API_BASE_URL);
+  // A missing or malformed credential is a source failure like any other, not
+  // a reason to abandon the repo-local sources. buildMaintenanceApiRequest
+  // throws on an empty key, and it sits outside the fetch guard below, so
+  // without this catch the whole producer exits non-zero and the launch and
+  // milestone rows are lost with it.
+  let request: { url: string; headers: Record<string, string> };
+  try {
+    request = buildMaintenanceApiRequest(API_PATHS.events(), API_KEY, API_BASE_URL);
+  } catch {
+    return null;
+  }
   const url = new URL(request.url);
   url.searchParams.set("class", classFilter);
   url.searchParams.set("severityFloor", "warning");
@@ -346,7 +365,7 @@ async function main(): Promise<void> {
   ]);
 
   if (depegEvents == null) {
-    notes.push(`depeg tape unreachable at ${API_BASE_URL} — skipped`);
+    notes.push(`depeg tape ${TAPE_SKIP_REASON} — skipped`);
   } else {
     for (const e of depegEvents) {
       const c = mapDepegCandidate(e);
@@ -355,7 +374,7 @@ async function main(): Promise<void> {
   }
 
   if (blacklistEvents == null) {
-    notes.push(`freeze tape unreachable at ${API_BASE_URL} — skipped`);
+    notes.push(`freeze tape ${TAPE_SKIP_REASON} — skipped`);
   } else {
     for (const e of blacklistEvents) {
       const c = mapBlacklistCandidate(e, resolveCoinId);
@@ -388,5 +407,11 @@ async function main(): Promise<void> {
 }
 
 if (isDirectRun(import.meta.url, process.argv[1])) {
-  void main();
+  // A genuine failure here means the queue could not be written. Report it as
+  // one line rather than an unhandled rejection: this runs in CI and the raw
+  // stack lands in the review issue body verbatim.
+  main().catch((err: unknown) => {
+    process.stderr.write(`Failed to build annotation candidates: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  });
 }

--- a/shared/data/annotations/curated-annotations.ts
+++ b/shared/data/annotations/curated-annotations.ts
@@ -1713,6 +1713,28 @@ export const CURATED_ANNOTATIONS: Record<string, readonly ChartAnnotation[]> = {
       label: "WUSD depeg low ~$0.97 — liquidity stress",
       severity: "med",
     },
+    {
+      // 2026-07-25 — MEXC ST-tagged WUSD on 07-22 and delisted it 07-25;
+      // Bitget removed WUSD/USDT on 07-31; Coins.ph, the flagship WUSD/PHP
+      // retail venue, delisted 08-04 citing WUSD no longer meeting its
+      // listing standards. Pinned at the first delisting; the Coins.ph
+      // notice is the only one of the three that states a reason.
+      ts: Date.UTC(2026, 6, 25),
+      kind: "regulatory",
+      label: "CEX delisting cascade — MEXC, Bitget and Coins.ph exit WUSD",
+      severity: "high",
+      href: "https://support.coins.ph/hc/en-us/articles/60655699647641",
+    },
+    {
+      // 2026-07-29 — largest single-day burn of the contraction: 8.39M to
+      // 2.21M, followed by 2.21M to 0.61M on 08-01. Circulating fell 9.99M
+      // (07-21) to 0.61M, ~94%, with primary redemption KYB-gated to
+      // qualified businesses. No issuer statement accompanied it.
+      ts: Date.UTC(2026, 6, 29),
+      kind: "mint-burn-spike",
+      label: "94% of supply redeemed — WUSD circulating falls 9.99M to 0.61M",
+      severity: "high",
+    },
   ],
   "xdai-gnosis": [
     {

--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -62,7 +62,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/methodology-versions/constants.ts",
-      "sha256": "439b9161355a9d87785d6d927667a57025e89b85f70a62e1826e88b51814f04a"
+      "sha256": "24bca4ddbc04aca4fdd1b6264971494a3163cf85743b9ff16b3c3ad929fdeefe"
     },
     {
       "path": "shared/lib/methodology-versions/current-version.json",
@@ -70,7 +70,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/methodology-versions/liquidity-score.ts",
-      "sha256": "9c7b1e25922218e43566c49c93acf0cba6ab8562f7b6e5f885297c8e72db4422"
+      "sha256": "6b0ccc7a652fd405a00c2537f87ceec8a948b8374b7ea995882eb333c0803988"
     },
     {
       "path": "shared/lib/methodology-versions/redemption-backstop.ts",
@@ -78,7 +78,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/p4-exit-route-capacity.ts",
-      "sha256": "616503f147b9fd663faff1b9325843d1fcd31754c660ab280ec77b9461d3fb41"
+      "sha256": "c2f2c1b0a8ec583a29a2072b3bb40a1dd5590b5b6120a5eb2d418c60245800f8"
     },
     {
       "path": "shared/lib/redemption-backstop-capacity.ts",
@@ -126,7 +126,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/redemption-backstop-configs/offchain-issuer/remediation-and-late-audit.ts",
-      "sha256": "f7cffa8fdb8cc28d3ca4dff980a15c919d7c0464df015c76d45ed42a7a481d2c"
+      "sha256": "8eaa94e9e8e3dbf939bc4435c7ccdf50f542f0a6b1e6fd26abb3065f8aa0ebbe"
     },
     {
       "path": "shared/lib/redemption-backstop-configs/offchain-issuer/shared.ts",
@@ -338,11 +338,11 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/types/market.ts",
-      "sha256": "06c3068d6c89f20c59b18284e01add63b5a0bbc3875f4764900a7e26353dd78b"
+      "sha256": "b7b4995337aef61c39858078b22850bbba88bbd989ced1e65da0b9cececa7436"
     },
     {
       "path": "shared/types/measured-execution.ts",
-      "sha256": "cdf9c5c98f0358860ae16d04c8289b462343c03ba71823949918e7ec18853091"
+      "sha256": "8a1223ac469032072cbf233a277596e94fd8cb74a1756b887caf34860831452e"
     },
     {
       "path": "shared/types/redemption.ts",
@@ -533,7 +533,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "f1562d9bdf8db70336973b7ac7ad3ab639a0d16db943b9a9d03a92cb91616b6c"
     }
   ],
-  "digest": "b15790dcc7f220d31e9a223c5b041ec8827063eb6e9ea720cbd3e7496359b0e1"
+  "digest": "94c6618e389c7dcec819cdd9c658083e94fc7c07a63ee4b1e15903b3427fab47"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/safety-score-v9/transfer-review-overlays-v1.json
+++ b/shared/data/safety-score-v9/transfer-review-overlays-v1.json
@@ -4871,6 +4871,68 @@
           ]
         }
       ]
+    },
+    {
+      "assetId": "wusd-worldwide",
+      "reviewedAt": "2026-08-19",
+      "reviewer": "Claude transfer-fact review (issue #865)",
+      "deployments": [
+        {
+          "chainId": "ethereum",
+          "contractOrTokenId": "0x7cd017ca5ddb86861fa983a34b5f495c6f898c41",
+          "scope": "canonical",
+          "posture": "restrictable",
+          "evidence": "At Ethereum block 25787562 the WSPN ERC1967 proxy resolved to a verified ERC20F AccessControl token: paused() returned false, totalSupply() was 552,285.91 WUSD, and PAUSER_ROLE, BURNER_ROLE, MINTER_ROLE, CONTRACT_ADMIN_ROLE and UPGRADER_ROLE are declared role constants. Probes for isBlacklisted(address), blacklisted(address), frozen(address) and isFrozen(address) all reverted, so no holder-selective denylist was found in those four common forms; a PAUSER_ROLE holder can still halt all transfers, so secondary transfers remain restrictable rather than permissionless.",
+          "sources": [
+            {
+              "label": "WUSD on Ethereum (Etherscan)",
+              "url": "https://etherscan.io/address/0x7cd017ca5ddb86861fa983a34b5f495c6f898c41"
+            },
+            {
+              "label": "Ethereum PublicNode RPC",
+              "url": "https://ethereum-rpc.publicnode.com"
+            }
+          ]
+        },
+        {
+          "chainId": "polygon",
+          "contractOrTokenId": "0x7cd017ca5ddb86861fa983a34b5f495c6f898c41",
+          "scope": "additional",
+          "posture": "restrictable",
+          "evidence": "At Polygon block 92278868 the same-address WSPN deployment exposed the identical ERC20F role set, with paused() false and totalSupply() 58,045.44 WUSD; the same four denylist probes reverted. This is native WSPN issuance rather than a bridged copy, per the reviewed bridge-route facts, and carries no transfer fee.",
+          "sources": [
+            {
+              "label": "WUSD on Polygon (Polygonscan)",
+              "url": "https://polygonscan.com/address/0x7cd017ca5ddb86861fa983a34b5f495c6f898c41"
+            },
+            {
+              "label": "Polygon PublicNode RPC",
+              "url": "https://polygon-bor-rpc.publicnode.com"
+            }
+          ]
+        },
+        {
+          "chainId": "viction",
+          "contractOrTokenId": "0xba73e59f11597c1c13b0d9114688efb6a6d430f6",
+          "scope": "additional",
+          "posture": "restrictable",
+          "evidence": "The Viction deployment charges a flat 100 WUSD protocol fee on token calls, verified at Viction block 112793798. minFee() and estimateFee(uint256) both return 100000000000000000000 against decimals() 18, and estimateFee is amount-independent, returning the same 100 WUSD for 0, 1 wei, 1 WUSD and 10,000 WUSD. eth_call transfer probes from the WUSD/C98 pool pin the boundary exactly: an amount of balance minus 100 WUSD succeeds, while balance minus 100 WUSD plus 1 wei reverts InsufficientBalance() (0xf4d678b8), so a holder must retain a full 100 WUSD on top of whatever is sent. approve(spender, 1) reverts the same way from a zero-balance address and succeeds from the funded pool, so authorising a DEX also costs 100 WUSD. paused() was false and issuer() equals owner() 0x42cc0bacf8286da37196e4391727d4f3ad478319. Viction totalSupply() was 48,461.45 WUSD, of which the WUSD/C98 pool held 48,122.94 (99.3%), so the fee applies to roughly 338 WUSD held elsewhere on this chain while making the only venue with live trading unreachable for any holder with less than 100 WUSD.",
+          "sources": [
+            {
+              "label": "WUSD on Viction (Vicscan)",
+              "url": "https://vicscan.xyz/address/0xba73e59f11597c1c13b0d9114688efb6a6d430f6"
+            },
+            {
+              "label": "Viction VRC25 issuer registry entry for WUSD",
+              "url": "https://issuer.viction.xyz/token/0xBA73E59F11597c1c13B0D9114688Efb6A6D430F6"
+            },
+            {
+              "label": "Viction public RPC",
+              "url": "https://rpc.viction.xyz"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/shared/data/stablecoins/coins/kusd-kerne.json
+++ b/shared/data/stablecoins/coins/kusd-kerne.json
@@ -45,9 +45,6 @@
       "url": "https://basescan.org/token/0x5c2efdf0d8d286959b42308966bc2b97f5680aa3"
     }
   ],
-  "jurisdiction": {
-    "country": "British Virgin Islands"
-  },
   "contracts": [
     {
       "chain": "base",

--- a/shared/data/stablecoins/coins/reusd-re-protocol.json
+++ b/shared/data/stablecoins/coins/reusd-re-protocol.json
@@ -103,6 +103,11 @@
       "chain": "tempo",
       "address": "0x20c000000000000000000000e09a4cfec804f102",
       "decimals": 6
+    },
+    {
+      "chain": "solana",
+      "address": "2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT",
+      "decimals": 9
     }
   ],
   "collateralQuality": "exotic",

--- a/shared/data/stablecoins/coins/wusd-worldwide.json
+++ b/shared/data/stablecoins/coins/wusd-worldwide.json
@@ -53,6 +53,13 @@
   "collateralQuality": "rwa",
   "custodyModel": "institutional-unregulated",
   "governanceQuality": "single-entity",
+  "notices": [
+    {
+      "type": "danger",
+      "title": "No market exit; 100 WUSD fee per Viction transfer",
+      "message": "WUSD lost every centralized venue between 2026-07-25 and 2026-08-04 — MEXC, Bitget, and Coins.ph, which stated WUSD is no longer able to adhere to its listing standards — and circulating supply fell about 94%, from 9,986,097 on 2026-07-21 to 610,332. Pharos publishes no price because no venue quotes one continuously: the only pool with live trading holds roughly $96k on Viction and absorbs about $490 before moving 2%. Direct redemption remains open but only through WSPN corporate accounts, which qualified businesses must apply and be verified for, so there is no retail exit at par. On Viction the token also charges a flat 100 WUSD fee on token calls, verified on-chain at block 112793798 and independent of the amount sent: a transfer requires the amount plus 100 WUSD, and approve() carries the same fee, so a wallet cannot authorise a swap of any size without holding 100 WUSD. https://issuer.viction.xyz/token/0xBA73E59F11597c1c13B0D9114688Efb6A6D430F6"
+    }
+  ],
   "liveReservesConfig": {
     "adapter": "curated-validated",
     "version": 1,

--- a/shared/data/stablecoins/domains/risk-review/reusd-re-protocol.json
+++ b/shared/data/stablecoins/domains/risk-review/reusd-re-protocol.json
@@ -98,8 +98,8 @@
   "bridgeRouteRisk": {
     "tier": "external-validated-network",
     "summary": "reUSD has one native Ethereum issuance route and eight Chainlink CCIP burn/mint representation routes. The canonical-side CCIP BurnWithFromMintTokenPool is bridge machinery: it holds the Ethereum token MINTER_ROLE but can mint only through validated CCIP releaseOrMint flow and configured remote-chain lanes/rate limits. Its governance Safe owner, CCIP router/RMN validation path, peer mappings, rate limits, and emergency curse gate are represented below; the native InsuranceCapitalLayer remains the only collateral-backed native minter.",
-    "reviewedAt": "2026-08-16",
-    "reviewer": "Codex FIX-05 reUSD bridge-boundary migration",
+    "reviewedAt": "2026-08-19",
+    "reviewer": "Codex FIX-05 reUSD bridge-boundary migration; Claude solana CCIP route review (issue #881)",
     "confidence": "verified",
     "protocols": [
       {
@@ -122,6 +122,10 @@
       {
         "label": "Re Protocol introduction",
         "url": "https://docs.re.xyz/getting-started-with-re/introduction-to-the-re-protocol"
+      },
+      {
+        "label": "reUSD on Solana (Solscan)",
+        "url": "https://solscan.io/account/2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT"
       }
     ],
     "routes": [
@@ -439,6 +443,49 @@
           {
             "label": "reUSD on Tempo explorer (verified 2026-07-20)",
             "url": "https://explore.tempo.xyz/address/0x20c000000000000000000000e09a4cfec804f102"
+          }
+        ]
+      },
+      {
+        "id": "solana:2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT",
+        "destinationChain": "solana",
+        "contractAddress": "2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT",
+        "protocol": "Chainlink CCIP (BurnMintTokenPool 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB)",
+        "issuanceModel": "bridge-representation",
+        "routeClass": "third-party",
+        "riskTier": "external-validated-network",
+        "semantics": "burn-mint",
+        "scope": "peripheral",
+        "reviewDisposition": "reviewed",
+        "reviewNote": "Verified on solana 2026-08-19 (slot 440124852). The SPL mint 2uxaYT1f… has decimals 9, supply 7,454,015.258947373, no freeze authority set to a program (the freeze-authority account is an unfunded system address), and mintAuthority ALGjEEQcjtJS7aQXvDPoFTLdp74t1ub9w8rVwKbsSHB2, which is an SPL multisig with numRequiredSigners 1 and numValidSigners 2. A decoded mintTo in that slot shows the live path: CCIP OffRamp offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm invokes ARM proxy RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 and BurnMintTokenPool 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB, which signs mintTo through multisig member HgkgFRLz76rJA2FBjJQQo41GkViewDngS4tpUKwTkhfo (a PDA holding no lamports or data). All four program IDs match Chainlink's published solana-mainnet CCIP directory entries for lane.offRamp, armProxy, poolPrograms.BurnMintTokenPool and router. Every mintTo in the 12-signature window sampled at the mint authority was CCIP OffRamp-driven and signed by that PDA. Control caveat, and the reason this route is not equivalent to the eight EVM CCIP legs: the 1-of-2 threshold means the second member, funded system account EsX25TxVd8Uc4CFBdqQCZM86aHw7KxxCdgLhpwrArJ8E, can mint unilaterally without CCIP. The sampled history shows no such mint, but the capability is unrevoked and the sample is not exhaustive.",
+        "mappingVersion": "bridge-route-facts-v1",
+        "observedAt": "2026-08-19",
+        "sourceChain": "ethereum",
+        "canonicalChain": "ethereum",
+        "controllerChain": "solana",
+        "controllerAddress": "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB",
+        "failureDomainKeys": [
+          "protocol:chainlink-ccip",
+          "contract:solana:41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB",
+          "contract:solana:ALGjEEQcjtJS7aQXvDPoFTLdp74t1ub9w8rVwKbsSHB2"
+        ],
+        "observedBlock": 440124852,
+        "sources": [
+          {
+            "label": "Chainlink CCIP directory — solana-mainnet",
+            "url": "https://docs.chain.link/ccip/directory/mainnet/chain/solana-mainnet"
+          },
+          {
+            "label": "reUSD SPL mint on Solana (Solscan)",
+            "url": "https://solscan.io/account/2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT"
+          },
+          {
+            "label": "CCIP OffRamp mintTo observed at slot 440124852",
+            "url": "https://solscan.io/tx/3AvN24hbPSLUCvyDBHpdcR6NYLnsdU9iKycUAwiCwfK6wH2UbxKKreK14EjeNy9f68AB8qHxyHwQ2qWthqCiK4ZQ"
+          },
+          {
+            "label": "Re Protocol smart-contract addresses",
+            "url": "https://docs.re.xyz/products/smart-contracts"
           }
         ]
       }

--- a/shared/lib/__tests__/redemption-backstops.test.ts
+++ b/shared/lib/__tests__/redemption-backstops.test.ts
@@ -512,7 +512,6 @@ describe("getRedemptionBackstopConfig", () => {
       "sbc-brale",
       "eurr-stablr",
       "usdr-stablr",
-      "wusd-worldwide",
       "audd-novatti",
     ] as const;
 
@@ -525,6 +524,17 @@ describe("getRedemptionBackstopConfig", () => {
       });
       expect(config?.docs?.length).toBeGreaterThan(0);
     }
+
+    // WUSD belongs to the same tranche but carries its own re-review stamp:
+    // the first-wave date predated the CEX delisting cascade that left the
+    // gated issuer route as the only exit (issue #865).
+    const wusd = getRedemptionBackstopConfig("wusd-worldwide");
+    expect(wusd).toMatchObject({
+      routeFamily: "offchain-issuer",
+      capacityModel: { kind: "supply-full", confidence: "documented-bound" },
+      reviewedAt: "2026-08-19",
+    });
+    expect(wusd?.docs?.length).toBeGreaterThan(0);
 
     expect(getRedemptionBackstopConfig("usdh-native-markets")).toMatchObject({
       costModel: { kind: "fee-bps", feeBps: 0 },

--- a/shared/lib/redemption-backstop-configs/offchain-issuer/remediation-and-late-audit.ts
+++ b/shared/lib/redemption-backstop-configs/offchain-issuer/remediation-and-late-audit.ts
@@ -56,11 +56,17 @@ export const REMEDIATION_AND_LATE_AUDIT_OFFCHAIN_CONFIGS: Record<string, Redempt
       ]),
     ],
   },
+  // Re-reviewed 2026-08-19 (issue #865). The issuer route itself is unchanged
+  // and still documented, but the prior 2026-03-23 stamp predated the events
+  // that made it the *only* route: WUSD lost every CEX venue between 07-25 and
+  // 08-04 and circulating fell ~94% (9.99M to 0.61M). A holder who cannot open
+  // a WSPN corporate account now has no exit at par, so the eligibility gate is
+  // named explicitly rather than left to the access model alone.
   "wusd-worldwide": {
     ...issuerBase,
-    ...reviewedDirectRedemptionSupplyFull,
+    ...documentedBoundSupplyFull("2026-08-19"),
     costModel: documentedVariableFee(
-      "Corporate-account redemptions convert WUSD to USD at a 1:1 rate; WSPN docs say the platform conversion has no handling fee, while bank or network fees may still apply",
+      "Redemption is limited to WSPN corporate accounts, which qualified businesses must apply and be verified for; there is no retail redemption path. Approved accounts convert WUSD to USD at a 1:1 rate and WSPN docs say the platform conversion has no handling fee, while bank or network fees may still apply",
     ),
     docs: [
       sourceRef("About WUSD", "https://developer.wspn.io/5768563m0", ["route", "capacity"]),

--- a/src/components/__tests__/reserve-treemap.test.tsx
+++ b/src/components/__tests__/reserve-treemap.test.tsx
@@ -12,7 +12,7 @@ describe("ReserveTreemap", () => {
       <ReserveTreemap reserves={[SLICE("USD deposits & T-bills", 100, "very-low")]} />,
     );
     expect(html).toContain("Reserve composition treemap: USD deposits &amp; T-bills 100%");
-    expect(html).toContain("aspect-ratio:6 / 5");
+    expect(html).toContain("aspect-[6/5]");
     expect(html).toContain("pharos-chart-stage");
   });
 

--- a/src/components/reserve-treemap.tsx
+++ b/src/components/reserve-treemap.tsx
@@ -185,10 +185,14 @@ export function ReserveTreemap({ reserves, badge }: ReserveTreemapProps) {
           )}
         </DetailSectionTitle>
       </div>
-      <div
-        className="mt-3 min-h-[200px] w-full min-w-0 shrink-0 overflow-hidden lg:max-h-[520px]"
-        style={{ aspectRatio: "6 / 5" }}
-      >
+      {/* Below lg the panel stacks in auto-height flow, so the stage keeps its
+          6/5 ratio (flex-1 would collapse to zero with no definite parent
+          height). At lg the report-card grid gives the right column a definite
+          height driven by the score column, so the stage flexes into whatever
+          that is instead of overflowing a width-derived ratio and clipping the
+          bottom row of tiles. The ratio lives in a class, not an inline style,
+          so the lg override can win. */}
+      <div className="mt-3 aspect-[6/5] min-h-[200px] w-full min-w-0 shrink-0 overflow-hidden lg:aspect-auto lg:min-h-[240px] lg:max-h-[520px] lg:flex-1 lg:shrink">
         <div
           ref={chartContainerRef}
           className="h-full min-w-0 overflow-hidden"

--- a/worker/src/lib/__tests__/cron-metadata-persistence.test.ts
+++ b/worker/src/lib/__tests__/cron-metadata-persistence.test.ts
@@ -59,4 +59,34 @@ describe("compactCronMetadataForPersistence", () => {
       },
     });
   });
+
+  it("preserves mxLedger scalars as top-level keys through oversized compaction", () => {
+    const chunk = "A".repeat(240);
+    const metadata = JSON.stringify({
+      reason: "dex-liquidity-publication",
+      mxLedgerV: 1,
+      mxLedgerKind: "A",
+      mxLedgerCycle: 1_787_120_160,
+      mxLedgerParts: 2,
+      mxLedger0: chunk,
+      mxLedger1: chunk,
+      bulk: Array.from({ length: 5_000 }, (_, index) => ({
+        pool: `pool-${index}`,
+        body: "x".repeat(120),
+      })),
+    });
+
+    const result = compactCronMetadataForPersistence(metadata);
+    expect(result.compacted).toBe(true);
+    const parsed = JSON.parse(result.metadata!) as Record<string, unknown>;
+    // Top-level scalars, not nested under diagnostics: producer history's
+    // normalizeHistoryMetadata drops nested objects, and the durable
+    // activation-gate ledger reads these keys from worker_producer_history.
+    expect(parsed.mxLedgerV).toBe(1);
+    expect(parsed.mxLedgerKind).toBe("A");
+    expect(parsed.mxLedgerCycle).toBe(1_787_120_160);
+    expect(parsed.mxLedgerParts).toBe(2);
+    expect(parsed.mxLedger0).toBe(chunk);
+    expect(parsed.mxLedger1).toBe(chunk);
+  });
 });

--- a/worker/src/lib/cron-metadata-persistence.ts
+++ b/worker/src/lib/cron-metadata-persistence.ts
@@ -67,6 +67,16 @@ export function compactCronMetadataForPersistence(
   const parsed = safeParseMetadata(metadata);
   const diagnostics: Record<string, unknown> = {};
   const entries = parsed ? Object.entries(parsed) : [];
+  // Measured-execution ledger chunks must survive compaction as TOP-LEVEL scalars:
+  // producer history keeps only top-level scalars (normalizeHistoryMetadata), and the
+  // durable activation-gate ledger reads them from there. Each is bounded to <=240 chars
+  // and at most a handful of parts, so preserving them cannot re-breach the byte cap.
+  const preservedLedgerScalars: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of entries) {
+    if (!key.startsWith("mxLedger")) continue;
+    const scalar = boundedScalar(value);
+    if (scalar !== undefined) preservedLedgerScalars[key] = scalar;
+  }
   for (const [key, value] of entries.slice(0, MAX_TOP_LEVEL_DIAGNOSTICS)) {
     const summary = summarizeDiagnostic(value);
     if (summary !== undefined) diagnostics[key] = summary;
@@ -76,6 +86,7 @@ export function compactCronMetadataForPersistence(
     : "cron-metadata-over-64-kib";
   const envelope: Record<string, unknown> = {
     reason,
+    ...preservedLedgerScalars,
     persistenceCompaction: {
       schemaVersion: 1,
       originalBytes,
@@ -101,6 +112,7 @@ export function compactCronMetadataForPersistence(
   if (utf8Bytes(compacted) > MAX_PERSISTED_CRON_METADATA_BYTES) {
     compacted = JSON.stringify({
       reason: "cron-metadata-over-64-kib",
+      ...preservedLedgerScalars,
       persistenceCompaction: { schemaVersion: 1, originalBytes, diagnosticsDropped: true },
     });
   }


### PR DESCRIPTION
Verification and resolution pass over the five open issues.

## What landed

**#856 — kUSD jurisdiction removed.** The BVI incorporation claim came from Kerne's own July 2026 coverage submission describing an intended structure. Kerne holds no incorporation anywhere and publishes that itself. Key removed rather than nulled: the schema is `.strict()` and optional, 168 of 404 coin files already omit it, none carry `null`, and `gusd-gate` had the same key deleted the same way in `81488a875`. Closes the half of #773 that never landed.

**#865 — WUSD record corrected, plus a danger notice.** Supply fell ~94% (9,986,097 → 610,332) with the largest burn on 2026-07-29; MEXC, Bitget and Coins.ph all delisted between 07-25 and 08-04, the last stating WUSD "no longer able to adhere to our listing standards". A reviewed transfer overlay now records the VRC25 finding verified at Viction block 112793798: `minFee()` and `estimateFee(uint256)` both return `100000000000000000000` against `decimals() 18`, amount-independent, with the transfer boundary pinned exactly and `approve()` reverting `InsufficientBalance()` from a zero-balance address — so authorising a DEX costs 100 WUSD. The redemption backstop is re-reviewed off its 149-day-old stamp, two annotations pin the cascade and the collapse, the AI summary is rewritten out of growth-stage framing, and a `danger` notice puts it all above the fold.

No characterization of intent anywhere. The evidence supports failure and abandonment, not misappropriation.

**#881 + #880 — reUSD Solana registered.** Both issues reduce to one missing registry entry: with no Solana in `contracts`, pool discovery never crawled the chain, dropping ~$1.9M of already-indexed Meteora DLMM depth. The contract ships with its bridge route, not before it — `mint-bridge-ownership.ts` requires reviewed route coverage for every authored deployment, and shipping the contract alone would have widened a control gap. `validateMintBridgeOwnership` returns 0 violations at 10 contracts / 10 routes.

The route review records that at a 1-of-2 multisig threshold a funded non-CCIP signer can mint unilaterally, which makes this route weaker than the eight EVM CCIP legs.

**#879 — maintenance CI hardened.** `PHAROS_API_KEY` was never created as a repo secret (regression from `e1fe197334`, 2026-07-28). Three consecutive weekly runs filed a broken report while reporting **green**, because the job used `set +e` and a `::warning`. The secret is now set and a manual run came back clean. This PR fixes the two things that let it hide: the producer degrades per its own docstring instead of exiting 1, and the workflow now errors and exits 1.

**#880 deferral documented.** Jupiter Lend DEX genuinely qualifies for the Liquidity Score — it is an AMM, not lending TVL — but no provider indexes it and Jupiter ships no REST endpoint, so ingesting it means reopening the Solana on-chain lane v6.0 just retired. Recorded as a known uncovered venue with a revisit trigger rather than silently dropped.

## Known gaps, deliberately left

reUSD supply is still understated by ~$8.19M: DefiLlama's `chainConfig` for stablecoin 339 has no `solana` key, and the missing-chain reconciliation lane needs CoinGecko > DefiLlama × 1.05 while the actual ratio is 1.0429. Not worked around locally — no manual supply override was added.

## Note on scope

This branch was cut from local `main`, which already carried two commits from a concurrent session (`67e4daa4c` reserve treemap, `71b2bcbb7` worker mxLedger). They are included here rather than split out.

## Verification

`npm run check:pr -- --base=origin/main` passes: 191 test files, 3007 tests, exit 0. `check:generated-artifacts`, `check:stablecoin-data`, `check:verified-doc-links`, `check:doc-source-paths` and `typecheck` all clean.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)