### PR TITLE
fix(dex): scope native confirmation to covered pool families

### DIFF
--- a/docs/dex-liquidity.md
+++ b/docs/dex-liquidity.md
@@ -2,7 +2,7 @@
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v6.0`
+- **Current methodology version:** `v6.1`
 - **Runtime/version source:** `shared/lib/methodology-versions/liquidity-score.ts`
 - **Public changelog route:** `/methodology/liquidity-score-changelog/`
 - **Structured changelog:** `shared/data/methodology-changelogs/liquidity-score/`
@@ -80,7 +80,7 @@ Once primary and direct pools have been projected into metrics and identity evid
 
 The consumer prefers direct-API pools over overlapping DeFiLlama pools via a conservative pool-identity model (exact pool id first, derived token-shape match second) before score computation, but only after those direct-API pools pass the shared TVL sanity gates used elsewhere in the pipeline. Direct-source precedence also requires measured non-zero 24h volume, which lets pool-state-only sources such as Slipstream expand coverage without replacing stronger overlapping DeFiLlama rows when authoritative volume telemetry is absent. The execution split changes only heap ownership and scheduling; scoring inputs, iteration order, publication fences, and methodology remain unchanged.
 
-For protocol families that already have a clean protocol-native direct fetch on that chain, staged discovery now also needs authoritative exact-id confirmation before it can contribute liquidity. That means GT/CG/DS rows cannot invent new Balancer, Fluid, Raydium, Orca, Meteora, PancakeSwap, Aerodrome, or Velodrome pools when the native fetch completed without degradation, even if the source emitted non-degrading parser or pagination warnings; the guard deliberately fails open only when that direct source is degraded or unavailable so staged discovery can still act as recovery coverage during an upstream incident.
+For protocol families that already have a clean protocol-native direct fetch on that chain, staged discovery also needs authoritative exact-id confirmation before it can contribute liquidity. The confirmation scope matches the inventory the native source actually covers: PancakeSwap v3/v4 claims are checked against its concentrated-liquidity inventory, and Aerodrome/Velodrome Slipstream claims are checked against their Slipstream inventories, while classic v2 pools remain eligible through exact-id staged discovery because those native fetchers do not enumerate them. GT/CG/DS rows therefore cannot invent pools inside a clean authoritative family, even when the source emitted non-degrading parser or pagination warnings; the guard deliberately fails open only when that family source is degraded or unavailable so staged discovery can still act as recovery coverage during an upstream incident. Full-family native sources such as Balancer, Fluid, Raydium, Orca, and Meteora continue to require exact confirmation across their declared chains.
 
 Dead or explicitly blocked DEX ids are excluded before they can become pool contributions. The live runtime blocklist currently includes Retro variants and Bunni variants, and those blocked venues are also ignored again during retained-pool filtering, challenger publication, and `dex_prices` publication for defense in depth.
 

--- a/shared/data/methodology-changelogs/liquidity-score/v6.ts
+++ b/shared/data/methodology-changelogs/liquidity-score/v6.ts
@@ -9,6 +9,22 @@ import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions
 // are newest-first by version.
 export const LIQUIDITY_SCORE_V6: readonly MethodologyChangelogEntry[] = [
   {
+    version: "6.1",
+    title: "Family-scoped authoritative confirmation for classic v2 pools",
+    date: "2026-08-21",
+    effectiveAt: 1787270400,
+    summary:
+      "Authoritative staged-pool confirmation now follows the exact protocol family enumerated by each native source, so Slipstream-only inventories no longer veto classic Aerodrome or Velodrome v2 pools outside their coverage.",
+    impact: [
+      "Aerodrome and Velodrome staged pools identified as Slipstream or concentrated liquidity still require an exact id from the clean protocol-native Slipstream inventory",
+      "Classic v2 Aerodrome and Velodrome pools remain eligible through exact-address CoinGecko Onchain, GeckoTerminal, or DexScreener discovery because the native Slipstream fetchers do not enumerate those pools",
+      "Full-family direct inventories such as Balancer, Fluid, Raydium, Orca, and Meteora retain exact-id confirmation across every declared chain, while PancakeSwap keeps its existing v3/v4-only confirmation scope",
+      "Base Dollar's launch BD/USDC Aerodrome stableswap can therefore contribute its discovered pool TVL, volume, and price instead of being mislabeled unobserved solely because an unrelated Slipstream inventory completed cleanly",
+    ],
+    commits: [],
+    reconstructed: false,
+  },
+  {
     version: "6.0",
     title: "Raydium double-count correction and native measured-lane retirement",
     date: "2026-08-20",

--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -62,7 +62,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/methodology-versions/constants.ts",
-      "sha256": "e183069904626a9424ba820041e5af7846834143da4c8e857105e0d830fb8d06"
+      "sha256": "639172eb5d97bcd859f93bd944229980f6046bd8c1755b08e17a43832821cb5b"
     },
     {
       "path": "shared/lib/methodology-versions/current-version.json",
@@ -533,7 +533,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "f1562d9bdf8db70336973b7ac7ad3ab639a0d16db943b9a9d03a92cb91616b6c"
     }
   ],
-  "digest": "cba3e17da0cebff405278717a8d9b666a55d388a80169cd3c793cf2b938c7018"
+  "digest": "2f05f18eee9b9650e0d31974b966de05702ea9338c760e56632d24dee3d2897c"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/lib/methodology-versions/constants.ts
+++ b/shared/lib/methodology-versions/constants.ts
@@ -20,7 +20,7 @@ export const DDR_METHODOLOGY_VERSION = "4.2";
 export const DDR_METHODOLOGY_VERSION_LABEL = methodologyLabel(DDR_METHODOLOGY_VERSION);
 export const DDR_METHODOLOGY_CHANGELOG_PATH = "/methodology/depeg-resolver-changelog/";
 
-export const LIQUIDITY_METHODOLOGY_VERSION = "6.0";
+export const LIQUIDITY_METHODOLOGY_VERSION = "6.1";
 export const LIQUIDITY_METHODOLOGY_VERSION_LABEL = methodologyLabel(LIQUIDITY_METHODOLOGY_VERSION);
 export const LIQUIDITY_METHODOLOGY_CHANGELOG_PATH = "/methodology/liquidity-score-changelog/";
 

--- a/src/app/methodology/sections/core/liquidity-section.test.tsx
+++ b/src/app/methodology/sections/core/liquidity-section.test.tsx
@@ -9,6 +9,6 @@ describe("LiquidityMethodologySection", () => {
     const markup = renderToStaticMarkup(<LiquidityMethodologySection />);
     const markupHash = createHash("sha256").update(markup).digest("hex");
 
-    expect(markupHash).toBe("4ac84131f459aaa1ac9a25ace64598ca0cc5a2050808be68b5b4de3bf1a4e07a");
+    expect(markupHash).toBe("c70957a796c437f617af8ce0110c5a6aeddebb8c0143e28661e7c7a35e7b299f");
   });
 });

--- a/worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts
@@ -1043,6 +1043,103 @@ describe("mergeStagedPools", () => {
     ]);
   });
 
+  it("does not apply Slipstream confirmation to classic Aerodrome staged pools", async () => {
+    const now = 1710000000;
+    const poolAddress = "0xffdf1e3160b60c2e499fa25e51b5c192b9b15e3b";
+    const mockDb = createMockDb([
+      {
+        pool_id: `base:${poolAddress}`,
+        stablecoin_id: "bd-basedollar",
+        source: "cg_onchain",
+        chain: "base",
+        protocol: "aerodrome",
+        dex_id: "aerodrome-base",
+        symbol: "BD/USDC",
+        tvl_usd: 83019.74,
+        volume_24h: 27452.2,
+        quality_multiplier: 0.3,
+        pool_type: "cg-amm",
+        fee_tier: null,
+        balance_ratio: null,
+        is_stable: null,
+        base_token: "0x252d36f435582ecb01686448d21e8c9ea0b2ca65",
+        quote_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        quote_symbol: "USDC",
+        price_usd: 1.0047,
+        locked_liq_pct: null,
+        discovered_at: now - 60,
+        refreshed_at: now,
+      },
+    ]);
+    const metrics = new Map();
+
+    const result = await mergeStagedPools(
+      mockDb,
+      metrics as never,
+      makeKnownPoolIndex(),
+      now,
+      undefined,
+      makeAuthoritativeConfirmationIndex([{ protocol: "aerodrome", chains: ["base"] }]),
+    );
+
+    expect(result.mergedCount).toBe(1);
+    expect(result.skippedByAuthoritativeProtocolCount).toBe(0);
+    expect(metrics.get("bd-basedollar")?.topPools[0]).toMatchObject({
+      poolId: `base:${poolAddress}`,
+      project: "aerodrome",
+    });
+  });
+
+  it("still requires exact confirmation for staged Aerodrome Slipstream pools", async () => {
+    const now = 1710000000;
+    const poolAddress = "0x1111111111111111111111111111111111111111";
+    const mockDb = createMockDb([
+      {
+        pool_id: `base:${poolAddress}`,
+        stablecoin_id: "bd-basedollar",
+        source: "cg_onchain",
+        chain: "base",
+        protocol: "aerodrome",
+        dex_id: "aerodrome-slipstream",
+        symbol: "BD/USDC",
+        tvl_usd: 100000,
+        volume_24h: 30000,
+        quality_multiplier: 0.7,
+        pool_type: "cg-cl-1bp",
+        fee_tier: 1,
+        balance_ratio: null,
+        is_stable: null,
+        base_token: "0x252d36f435582ecb01686448d21e8c9ea0b2ca65",
+        quote_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        quote_symbol: "USDC",
+        price_usd: 1.0047,
+        locked_liq_pct: null,
+        discovered_at: now - 60,
+        refreshed_at: now,
+      },
+    ]);
+    const metrics = new Map();
+
+    const result = await mergeStagedPools(
+      mockDb,
+      metrics as never,
+      makeKnownPoolIndex(),
+      now,
+      undefined,
+      makeAuthoritativeConfirmationIndex([{ protocol: "aerodrome", chains: ["base"] }]),
+    );
+
+    expect(result.mergedCount).toBe(0);
+    expect(result.skippedByAuthoritativeProtocolCount).toBe(1);
+    expect(metrics.size).toBe(0);
+    expect(result.skipDimensions).toContainEqual({
+      reason: "authoritative_confirmation_missing",
+      protocol: "aerodrome",
+      chain: "base",
+      count: 1,
+    });
+  });
+
   it("fails open for staged pools when authoritative confirmation is unavailable", async () => {
     const now = 1710000000;
     const confirmedBalancerPool = "0x01e2c7fcde2b8d5d1413732c4e274ba5b06b1e54";

--- a/worker/src/cron/dex-liquidity/staging-merge.ts
+++ b/worker/src/cron/dex-liquidity/staging-merge.ts
@@ -335,10 +335,17 @@ function requiresAuthoritativeProtocolConfirmation(
   dexId: string,
 ): boolean {
   if (!authoritativeConfirmation) return false;
+  const familyDescriptor = `${dexId} ${poolType}`.toLowerCase();
   if (protocol === "pancakeswap") {
-    const familyDescriptor = `${dexId} ${poolType}`.toLowerCase();
     if (familyDescriptor.includes("v2")) return false;
     if (!/(v3|v4|concentrated|\bclmm\b|\bcg-cl-)/.test(familyDescriptor)) return false;
+  }
+  if (protocol === "aerodrome" || protocol === "velodrome") {
+    // The protocol-native fetchers cover Slipstream only. Do not let a clean
+    // concentrated-liquidity inventory veto classic v2 pools that are outside
+    // that source's declared family; those remain eligible through exact-id
+    // staged discovery. Slipstream claims still require exact confirmation.
+    if (!/(slipstream|concentrated|\bclmm\b|\bcg-cl-)/.test(familyDescriptor)) return false;
   }
   const enforcedChains = authoritativeConfirmation.enforcedChainsByProtocol.get(protocol);
   return enforcedChains?.has(chain.toLowerCase()) ?? false;


### PR DESCRIPTION
## Summary
- scope Aerodrome/Velodrome authoritative confirmation to Slipstream/concentrated pools, matching what their native fetchers enumerate
- keep classic v2 pools eligible through exact-address discovery instead of treating a clean Slipstream inventory as a veto
- add regression coverage for classic and Slipstream Aerodrome rows
- document Liquidity Score v6.1 and refresh the V9 evaluation-build identity

## Production finding
The exact BD Base Aerodrome pool was discovered at `0xffdf1e3160b60c2e499fa25e51b5c192b9b15e3b` with about $83k TVL, but the 12:16 publication rejected it as `authoritative_confirmation_missing` because the native provider covers Slipstream only. This change fixes that family-scope mismatch without weakening full-family confirmation.

## Validation
- focused DEX tests: 42 passed
- root and Worker TypeScript checks passed
- stablecoin data, doc sync, cron schedule/connection checks passed
- full generated-artifact graph passed
- `git diff --check` passed

A baseline verified-doc-link failure in `docs/runbooks/yield-rankings-stale-or-missing.md` is unrelated to this diff.