### PR TITLE
ci(safety-map): enable the daily 07:20 UTC schedule

### DIFF
--- a/.github/workflows/safety-map-refresh.yml
+++ b/.github/workflows/safety-map-refresh.yml
@@ -87,8 +87,8 @@ on:
   # actions above are done. 07:20 UTC leaves ~45 min of headroom before the
   # 08:05 UTC digest cron, deliberately wide because Actions schedules are
   # routinely delayed 5-20 minutes at peak (plan §11.2a).
-  # schedule:
-  #   - cron: "20 7 * * *"
+  schedule:
+    - cron: "20 7 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Turns on the Safety Map's daily refresh. Two lines: uncommenting the `schedule:` block.

The gate this was waiting on has been met. Dispatch run [32480900376](https://github.com/TokenBrice/pharos-watch/actions/runs/32480900376) on `main` completed all 18 steps and published the full key set, and the live surfaces were verified afterwards:

- `safety-map:latest.json` carries today's UTC date, edition `daily`, methodology 9.31, 319 graded / 17 not rated.
- `/safety-scores/map.png` serves 200 `image/png` at 1,053,546 bytes — matching the manifest exactly — with the short-lived cache plus `stale-while-revalidate`.
- `?date=2026-08-21` serves 200 `immutable`, so the dated URL the digest is meant to embed resolves.
- The page renders the poster at its true 3200x1800 and drops the unavailable panel.

Before those keys existed, the same page rendered the explanatory panel and `map.png` returned 404 with `no-store`, so the kill-switch state was observed in production rather than assumed.

07:20 UTC leaves ~45 minutes before the 08:05 digest cron, deliberately wide because Actions schedules are routinely delayed 5-20 minutes at peak.

Note for the first scheduled run: the delta guard skipped on the dispatch (no prior snapshot existed) and will execute for the first time tomorrow, now that one is stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)