### PR TITLE
Add Base Dollar yield and compliance coverage

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2673,7 +2673,7 @@ Set `projection=summary` for the compact workbench contract. It preserves leader
   },
   "methodology": {
     "version": "8.37",
-    "currentVersion": "8.40",
+    "currentVersion": "8.41",
     "changelogPath": "/methodology/yield-changelog/"
   },
   "_meta": { "updatedAt": 1710500000, "ageSeconds": 42, "status": "fresh" }
@@ -2837,7 +2837,7 @@ Yield adapter manifest for every yield-bearing asset. The route is public-read, 
 
 ```text
 {
-  "methodologyVersion": "v8.40",
+  "methodologyVersion": "v8.41",
   "updatedAt": 1779210000,
   "entries": [
     {
@@ -2851,7 +2851,7 @@ Yield adapter manifest for every yield-bearing asset. The route is public-read, 
       "project": null,
       "lifecycle": "active",
       "quarantineReason": null,
-      "methodologyVersion": "v8.40",
+      "methodologyVersion": "v8.41",
       "updatedAt": 1779210000
     }
   ]
@@ -2906,7 +2906,7 @@ For tracked savings-wrapper handoffs (`USDe`, `USDS`, `DAI`, `frxUSD`, `crvUSD`,
   },
   "methodology": {
     "version": "8.37",
-    "currentVersion": "8.40",
+    "currentVersion": "8.41",
     "changelogPath": "/methodology/yield-changelog/"
   }
 }
@@ -2942,7 +2942,7 @@ For tracked savings-wrapper handoffs (`USDe`, `USDS`, `DAI`, `frxUSD`, `crvUSD`,
   "pysAtPublish": 42.7,
   "pysInputsAtPublish": {
     "schemaVersion": 1,
-    "methodologyVersion": "8.40",
+    "methodologyVersion": "8.41",
     "apy30d": 12.1,
     "safetyScore": 81,
     "varianceScore": 0.18,

--- a/docs/yield-intelligence.md
+++ b/docs/yield-intelligence.md
@@ -8,7 +8,7 @@ Risk-adjusted yield tracking and ranking for yield-bearing stablecoins and curat
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v8.40`
+- **Current methodology version:** `v8.41`
 - **Public changelog page:** `/methodology/yield-changelog/`
 - **Canonical source:** `shared/lib/methodology-versions/yield-methodology.ts`
 
@@ -139,9 +139,24 @@ apr                  = remainingLqtyRewards * dailyIssuanceFactor * lqtyPriceUsd
 
 **Caveat:** This source captures only the projected LQTY incentive stream. It deliberately excludes ETH liquidation gains, so it is a lower-bound estimate of the full Stability Pool return.
 
-#### Reviewed gap: Base Dollar Stability Pools
+#### Special-case Tier 1 estimator: Base Dollar Liquity V2 Stability Pools
 
-BD has five branch-specific Liquity V2 Stability Pools on Base. Their variable return combines BD borrower-fee distributions with collateral liquidation gains, so neither the generic ERC-4626 exchange-rate reader nor the Liquity v1 B.Protocol emissions estimator can represent it safely. At the 2026-08-21 launch review there was no verified public machine-readable APY feed or yield-bearing wrapper exchange rate. The typed yield lifecycle registry therefore records an intentional `source-family-adapter-unimplemented` gap through 2026-09-21. The next implementation step is a reusable multi-branch Liquity V2 Stability Pool adapter that snapshots every branch's deposit and reward accumulators, values collateral gains, and fails closed unless branch coverage is complete.
+Base Dollar has five branch-specific Liquity V2 Stability Pools on Base: WETH, wstETH, rETH, cbBTC, and cbETH. This deterministic row is labeled `Base Dollar Stability Pools (interest-only)` and publishes under source key `onchain:bd-basedollar` with `yieldType: lending-vault`; `sourceTvlUsd` is the total BD deposited across the five pools. Base Dollar itself is not yield-bearing — the Stability Pool is the deposit venue, as with LUSD.
+
+**Reads:**
+
+- One batched `eth_call` read per refresh: the CollateralRegistry branch count plus each branch's Stability Pool BD deposits, `aggWeightedDebtSum`, and shutdown state
+
+**Formula:**
+
+```
+aggregateBorrowerInterest = Σ activeBranch(aggWeightedDebtSum)
+apr = 0.75 * aggregateBorrowerInterest / totalStabilityPoolBDDeposits * 100
+```
+
+Shutdown branches contribute zero. The reader fails closed if any read fails or if the CollateralRegistry reports a branch count different from the five configured branches (e.g. after a governor registers an announced AERO/LP branch), so the row is published only with complete branch coverage.
+
+**Caveat:** This is a deliberately conservative interest-only undercount. It excludes upfront borrowing fees and liquidation collateral gains, so it does not represent the full Stability Pool return.
 
 ### Tier 2: DeFiLlama Yields API (Multi-Source)
 
@@ -213,6 +228,7 @@ External `lending-opportunity`, `fixed-yield`, and `structured-tranche` rows und
 | `usbd-bima`           | `BIMA savings (sUSBD)`              | `https://bima.money/api/earn/pools?network=Ethereum&user=0x0000000000000000000000000000000000000000` |
 | `cetes-etherfuse`     | `Etherfuse CETES current issuance`  | Etherfuse first-party Next data at `https://app.etherfuse.com/bonds/cetes`                           |
 | `lusd-liquity`        | `B.Protocol LQTY-only source`       | deterministic on-chain LQTY-only source reader                                                       |
+| `bd-basedollar`       | `Base Dollar Stability Pools (interest-only)` | deterministic on-chain five-branch Liquity V2 Stability Pool reader                              |
 | `usyc-hashnote`       | `Hashnote USYC`                     | Hashnote protocol API                                                                                |
 | `mmev-midas`          | `Midas mMEV/USD Oracle`             | on-chain issuer-listed mMEV/USD NAV oracle with historical anchor rows                               |
 | `usdy-ondo-finance`   | `Ondo USDY oracle`                  | on-chain Ondo oracle with historical anchor rows                                                     |

--- a/shared/data/methodology-changelogs/yield-methodology/v8.ts
+++ b/shared/data/methodology-changelogs/yield-methodology/v8.ts
@@ -2,6 +2,21 @@ import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions
 
 export const YIELD_METHODOLOGY_V8: readonly MethodologyChangelogEntry[] = [
   {
+    version: "8.41",
+    title: "Base Dollar Liquity V2 Stability Pool Source",
+    date: "2026-08-21",
+    effectiveAt: 1787270400,
+    summary:
+      "The first multi-branch Liquity V2 Stability Pool on-chain source now covers Base Dollar through a deterministic interest-only APR: 75% of aggregate accrued borrower interest across its five Base branches divided by total Stability Pool BD deposits. Direct eth_call reads fail closed unless every branch is readable, and the deliberately conservative estimate excludes upfront borrowing fees and liquidation collateral gains; this replaces the 2026-08-21 `source-family-adapter-unimplemented` intentional gap for `bd-basedollar`.",
+    impact: [
+      "`bd-basedollar` moves from intentional-gap to covered through the deterministic `onchain:bd-basedollar` reader, publishing the Base Dollar Stability Pools (interest-only) lending-vault row with total Stability Pool deposits as `sourceTvlUsd`; Base Dollar itself remains non-yield-bearing, with yield attributed to the deposit venue",
+      "The reader aggregates `aggWeightedDebtSum` across WETH, wstETH, rETH, cbBTC, and cbETH Stability Pool branches, treats shut-down branches as zero, and requires complete branch coverage before publishing",
+      "The Liquity V2 Stability Pool source family is reusable for other Liquity V2 forks while preserving the same conservative interest-only undercount and fail-closed branch-read contract",
+    ],
+    commits: [],
+    reconstructed: false,
+  },
+  {
     version: "8.40",
     title: "Measured Venue TVL Eligibility and Native Depth Semantics",
     date: "2026-08-20",

--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -62,7 +62,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/methodology-versions/constants.ts",
-      "sha256": "639172eb5d97bcd859f93bd944229980f6046bd8c1755b08e17a43832821cb5b"
+      "sha256": "96dea61d775353cf6a75822b110d114c92f0fa7c04fc37a7e7a8f6ca88598867"
     },
     {
       "path": "shared/lib/methodology-versions/current-version.json",
@@ -533,7 +533,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "f1562d9bdf8db70336973b7ac7ad3ab639a0d16db943b9a9d03a92cb91616b6c"
     }
   ],
-  "digest": "2f05f18eee9b9650e0d31974b966de05702ea9338c760e56632d24dee3d2897c"
+  "digest": "dbb8990a64e951876e3e8f84e1da5bff5ac816de64b589076c6c859d18623bd0"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/stablecoins/domains/compliance/bd-basedollar.json
+++ b/shared/data/stablecoins/domains/compliance/bd-basedollar.json
@@ -1,0 +1,118 @@
+{
+  "id": "bd-basedollar",
+  "mica": {
+    "status": "out-of-scope"
+  },
+  "genius": {
+    "applicability": "unclear",
+    "applicabilityBasis": {
+      "summary": "BD is minted when users borrow against overcollateralized positions in a decentralized Liquity V2-style protocol and can be redeemed permissionlessly for on-chain collateral. No legal person obligated to convert, redeem, or repurchase BD for a fixed amount of monetary value is identified, leaving its treatment under the GENIUS payment-stablecoin definition unclear.",
+      "references": [
+        {
+          "label": "GENIUS Act — payment stablecoin definition",
+          "url": "https://www.govinfo.gov/content/pkg/PLAW-119publ27/html/PLAW-119publ27.htm",
+          "sourceKind": "statute",
+          "sourceDate": "2025-07-18",
+          "accessedAt": "2026-08-21"
+        },
+        {
+          "label": "Base Dollar general documentation",
+          "url": "https://docs.basedollar.org/docs/user-docs/general",
+          "sourceKind": "issuer-disclosure",
+          "accessedAt": "2026-08-21"
+        },
+        {
+          "label": "Base Dollar redemption documentation",
+          "url": "https://docs.basedollar.org/docs/user-docs/redemption-and-delegation",
+          "sourceKind": "issuer-disclosure",
+          "accessedAt": "2026-08-21"
+        }
+      ]
+    },
+    "authorizationStatus": "no-public-authorization-found",
+    "issuerPathway": "unknown",
+    "foreignExceptionStatus": "unknown",
+    "enforcementStatus": "no-public-action-found",
+    "daspOfferSaleStatus": "not-yet-restricted",
+    "reserveDisclosurePresent": false,
+    "redemptionPolicyPresent": true,
+    "monthlyAttestationPresent": false,
+    "notes": "Explicitly assessed for cohort parity with other tracked Liquity V2-class stablecoins despite BD's launch-scale supply. Base Dollar's materials describe protocol-level borrowing and collateral redemption, but do not identify a conventional legal issuer or a GENIUS issuer pathway. Public on-chain collateral visibility is not treated as the issuer reserve disclosure or monthly attestation contemplated by GENIUS. No public approval, state qualification, official application, foreign-issuer registration, or enforcement action was located; the regime remains in proposed-rules phase.",
+    "references": [
+      {
+        "label": "GENIUS Act — payment stablecoin definition and issuer limitation",
+        "url": "https://www.govinfo.gov/content/pkg/PLAW-119publ27/html/PLAW-119publ27.htm",
+        "sourceKind": "statute",
+        "sourceDate": "2025-07-18",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "OCC Bulletin 2026-3 — GENIUS Act proposed rule",
+        "url": "https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-3.html",
+        "sourceKind": "federal-regulator",
+        "sourceDate": "2026-02-25",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "Treasury proposed GENIUS issuance, offer, and sale rule",
+        "url": "https://www.federalregister.gov/documents/2026/08/18/2026-16796/genius-act-regulations-on-payment-stablecoin-issuance-offer-and-sale",
+        "sourceKind": "federal-register",
+        "sourceDate": "2026-08-18",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "OCC digital assets licensing applications",
+        "url": "https://occ.gov/topics/charters-and-licensing/digital-assets-licensing-applications/index-digital-assets-licensing-applications.html",
+        "sourceKind": "regulator-directory",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "New York DFS virtual currency regulated entities and Greenlist",
+        "url": "https://www.dfs.ny.gov/virtual_currency_businesses",
+        "sourceKind": "state-regulator",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "Base Dollar website",
+        "url": "https://basedollar.org/",
+        "sourceKind": "issuer-disclosure",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "Base Dollar general documentation",
+        "url": "https://docs.basedollar.org/docs/user-docs/general",
+        "sourceKind": "issuer-disclosure",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "Base Dollar redemption documentation",
+        "url": "https://docs.basedollar.org/docs/user-docs/redemption-and-delegation",
+        "sourceKind": "issuer-disclosure",
+        "accessedAt": "2026-08-21"
+      },
+      {
+        "label": "Base Dollar protocol repository",
+        "url": "https://github.com/basedollar/basedollar",
+        "sourceKind": "issuer-disclosure",
+        "accessedAt": "2026-08-21"
+      }
+    ],
+    "negativeEvidenceReview": {
+      "sourcesChecked": [
+        "https://basedollar.org/ — describes a decentralized borrowing protocol but names no legal issuer, U.S. license, GENIUS application, or reserve-attestation program.",
+        "https://docs.basedollar.org/docs/user-docs/general — describes user-minted BD, collateral, and limited governance but identifies no issuer entity or regulatory pathway.",
+        "https://docs.basedollar.org/docs/user-docs/redemption-and-delegation — documents permissionless protocol redemption for collateral, not redemption by a legal issuer for fixed monetary value.",
+        "https://github.com/basedollar/basedollar — documents the Liquity V2 fork and protocol mechanics but contains no public GENIUS authorization, application, or issuer disclosure.",
+        "https://occ.gov/topics/charters-and-licensing/digital-assets-licensing-applications/index-digital-assets-licensing-applications.html — the OCC pending digital-assets application table contains no Base Dollar or Basedollar applicant.",
+        "https://www.federalregister.gov/api/v1/documents.json?per_page=20&conditions%5Bterm%5D=Base%20Dollar%20stablecoin — the search returned general GENIUS rulemaking and unrelated lexical matches, with no BD-specific authorization, application, foreign exception, or enforcement action.",
+        "https://www.dfs.ny.gov/virtual_currency_businesses — New York DFS regulated-entity, limited-purpose trust, and approved-stablecoin Greenlist entries do not name Base Dollar, Basedollar, or BD.",
+        "https://news.google.com/rss/search?q=%22Base%20Dollar%22%20stablecoin%20when%3A30d&hl=en-US&gl=US&ceid=US%3Aen — exact-name news search returned no relevant application, authorization, or enforcement coverage."
+      ],
+      "summary": "No public GENIUS PPSI approval, state-qualified approval, official application, registered foreign-issuer exception, or enforcement action was found for BD or an identifiable Base Dollar issuer. Project materials instead describe permissionless borrowing and collateral redemption through a decentralized protocol without naming a legal issuer.",
+      "reviewer": "Codex compliance research",
+      "reviewedAt": "2026-08-21"
+    },
+    "reviewer": "Codex compliance research",
+    "reviewedAt": "2026-08-21"
+  }
+}

--- a/shared/lib/methodology-versions/constants.ts
+++ b/shared/lib/methodology-versions/constants.ts
@@ -49,6 +49,6 @@ export const PSI_METHODOLOGY_VERSION = "3.6";
 export const PSI_METHODOLOGY_VERSION_LABEL = methodologyLabel(PSI_METHODOLOGY_VERSION);
 export const PSI_METHODOLOGY_CHANGELOG_PATH = "/methodology/stability-index-changelog/";
 
-export const YIELD_METHODOLOGY_VERSION = "8.40";
+export const YIELD_METHODOLOGY_VERSION = "8.41";
 export const YIELD_METHODOLOGY_VERSION_LABEL = methodologyLabel(YIELD_METHODOLOGY_VERSION);
 export const YIELD_METHODOLOGY_CHANGELOG_PATH = "/methodology/yield-changelog/";

--- a/src/app/methodology/sections/monitoring/yield-intelligence-section.tsx
+++ b/src/app/methodology/sections/monitoring/yield-intelligence-section.tsx
@@ -141,7 +141,8 @@ export function YieldIntelligenceMethodologySection() {
                     <li>
                       <span className="text-foreground">Tier 1 &mdash; Direct on-chain reads</span>: reads protocol state
                       directly, either as an exchange-rate delta (e.g.&nbsp;sUSDe), a conservative reward-only estimator
-                      (e.g.&nbsp;LUSD B.Protocol Stability Pool, LQTY only), or scrvUSD&apos;s Yearn V3 profit-unlock current-rate reader
+                      (e.g.&nbsp;LUSD B.Protocol Stability Pool, LQTY only), a multi-branch interest-only estimator
+                      (e.g.&nbsp;Base Dollar Liquity V2 Stability Pools), or scrvUSD&apos;s Yearn V3 profit-unlock current-rate reader
                     </li>
                     <li>
                       <span className="text-foreground">Tier 2 &mdash; DeFiLlama pools</span>: matches the coin to a
@@ -312,6 +313,11 @@ export function YieldIntelligenceMethodologySection() {
                     <li>
                       The LUSD B.Protocol Stability Pool row is conservative by design: it includes projected LQTY
                       incentives only and excludes ETH liquidation gains
+                    </li>
+                    <li>
+                      The Base Dollar Liquity V2 Stability Pool row is conservative by design: it includes 75% of
+                      accrued borrower interest only, requires complete five-branch reads, and excludes upfront
+                      borrowing fees and liquidation collateral gains
                     </li>
                     <li>Price-derived APY (Tier 3) can be noisy for low-liquidity NAV tokens</li>
                   </ul>

--- a/worker/src/cron/__tests__/yield-basedollar-sp-source.test.ts
+++ b/worker/src/cron/__tests__/yield-basedollar-sp-source.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mockFetchRetry } from "../../test-helpers/cron";
+import type { ChainRpcConfig } from "../../lib/chain-registry";
+
+vi.mock("../../lib/fetch-retry", () => mockFetchRetry());
+
+import { fetchBasedollarSpSource } from "../yield-sync/sources";
+
+const TEST_CHAIN_RPCS = new Map<string, ChainRpcConfig>([
+  [
+    "base",
+    {
+      chainId: "base",
+      chainName: "Base",
+      type: "evm",
+      rpcUrl: "https://rpc.example/base",
+      fallbackRpcUrl: "https://rpc-fallback.example/base",
+      explorerUrl: "https://basescan.org",
+    },
+  ],
+]);
+
+const E18 = 10n ** 18n;
+const E36 = 10n ** 36n;
+const TOTAL_COLLATERALS_SELECTOR = "0x30504b6f";
+const AGG_WEIGHTED_DEBT_SUM_SELECTOR = "0x42635a95";
+const SHUTDOWN_TIME_SELECTOR = "0x58569081";
+const TOTAL_BOLD_DEPOSITS_SELECTOR = "0xf71c6940";
+const COLLATERAL_REGISTRY = "0x7551ebfc8340b7f91874942be9c653733d4fb04f";
+const BRANCHES = [
+  {
+    activePool: "0x254a8267d4e12a8c0f283274632a18a33e49f7c0",
+    stabilityPool: "0x7d837bf114785642d225d1101145ddb8af4ba438",
+  },
+  {
+    activePool: "0x1021fefc406c9573ab3579fc55be13e3300ef6b1",
+    stabilityPool: "0xc65a05737d31e0f42c0806c739f3c88dd009c05f",
+  },
+  {
+    activePool: "0x1b9a62798e8bae0cea4eb21b4b3775359beb819f",
+    stabilityPool: "0x4eb3b6970fd358d34195b5d40e4eb64e0e3c0b6a",
+  },
+  {
+    activePool: "0xcaa72df531554087318eaf24646958500668b230",
+    stabilityPool: "0x6bd55dd953507641c84a03956760f83d29d65726",
+  },
+  {
+    activePool: "0xddac84ab417677f553cced8ababf497226112218",
+    stabilityPool: "0x25afbb09d9804482ed8e24295be4a12704fe93ea",
+  },
+] as const;
+
+interface BranchValues {
+  yearlyInterest: bigint;
+  shutdownTime: bigint;
+  deposits: bigint;
+}
+
+function uint256Hex(value: bigint): string {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+
+function stubBasedollarRpc(
+  values: readonly BranchValues[],
+  options?: { failRead?: { branchIndex: number; selector: string }; registryCount?: bigint },
+) {
+  function resolveCall(to: string | undefined, data: string | undefined): string {
+    if (to === COLLATERAL_REGISTRY && data === TOTAL_COLLATERALS_SELECTOR) {
+      return uint256Hex(options?.registryCount ?? BigInt(BRANCHES.length));
+    }
+    for (const [index, branch] of BRANCHES.entries()) {
+      if (options?.failRead?.branchIndex === index && options.failRead.selector === data) {
+        // An empty eth_call result is not a valid uint256 word; the adapter
+        // must reject the whole batch rather than publish a partial sum.
+        return "0x";
+      }
+      if (to === branch.activePool && data === AGG_WEIGHTED_DEBT_SUM_SELECTOR) {
+        return uint256Hex(values[index]!.yearlyInterest * E36);
+      }
+      if (to === branch.activePool && data === SHUTDOWN_TIME_SELECTOR) {
+        return uint256Hex(values[index]!.shutdownTime);
+      }
+      if (to === branch.stabilityPool && data === TOTAL_BOLD_DEPOSITS_SELECTOR) {
+        return uint256Hex(values[index]!.deposits * E18);
+      }
+    }
+    throw new Error(`Unexpected Base Dollar eth_call: ${to ?? "missing-to"} ${data ?? "missing-data"}`);
+  }
+
+  vi.stubGlobal("fetch", vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as Array<{
+      id?: number;
+      params?: Array<{ to?: string; data?: string } | string>;
+    }>;
+    if (!Array.isArray(body)) {
+      throw new Error("Expected a JSON-RPC batch request from fetchEvmRpcBatch");
+    }
+    const envelopes = body.map((call) => {
+      const params = typeof call.params?.[0] === "object" ? call.params[0] : null;
+      return {
+        jsonrpc: "2.0",
+        id: call.id,
+        result: resolveCall(params?.to?.toLowerCase(), params?.data),
+      };
+    });
+    return new Response(JSON.stringify(envelopes), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }));
+}
+
+const DEFAULT_BRANCH_VALUES: readonly BranchValues[] = [
+  { yearlyInterest: 100n, shutdownTime: 0n, deposits: 1_000n },
+  { yearlyInterest: 200n, shutdownTime: 0n, deposits: 2_000n },
+  { yearlyInterest: 300n, shutdownTime: 0n, deposits: 3_000n },
+  { yearlyInterest: 400n, shutdownTime: 0n, deposits: 4_000n },
+  { yearlyInterest: 500n, shutdownTime: 0n, deposits: 5_000n },
+];
+
+describe("fetchBasedollarSpSource", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("computes the deposit-weighted interest-only APR across all branches", async () => {
+    stubBasedollarRpc(DEFAULT_BRANCH_VALUES);
+
+    const result = await fetchBasedollarSpSource(undefined, TEST_CHAIN_RPCS);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        currentApy: 7.5,
+        apyBase: 7.5,
+        apyReward: null,
+        sourcePool: null,
+        sourceTvlUsd: 15_000,
+        dataSource: "onchain",
+        exchangeRate: null,
+        sourceKey: "onchain:bd-basedollar",
+        yieldSource: "Base Dollar Stability Pools (interest-only)",
+        yieldType: "lending-vault",
+      }),
+    );
+  });
+
+  it("excludes a shutdown branch's interest but retains its deposits", async () => {
+    stubBasedollarRpc(DEFAULT_BRANCH_VALUES.map((branch, index) => (
+      index === 2 ? { ...branch, shutdownTime: 1n } : branch
+    )));
+
+    const result = await fetchBasedollarSpSource(undefined, TEST_CHAIN_RPCS);
+
+    expect(result?.currentApy).toBeCloseTo(6, 10);
+    expect(result?.apyBase).toBeCloseTo(6, 10);
+    expect(result?.sourceTvlUsd).toBe(15_000);
+  });
+
+  it("fails closed when any branch read in the batch is unreadable", async () => {
+    stubBasedollarRpc(DEFAULT_BRANCH_VALUES, {
+      failRead: { branchIndex: 3, selector: SHUTDOWN_TIME_SELECTOR },
+    });
+
+    await expect(fetchBasedollarSpSource(undefined, TEST_CHAIN_RPCS)).resolves.toBeNull();
+  });
+
+  it("fails closed when the CollateralRegistry reports more branches than configured", async () => {
+    stubBasedollarRpc(DEFAULT_BRANCH_VALUES, { registryCount: 6n });
+
+    await expect(fetchBasedollarSpSource(undefined, TEST_CHAIN_RPCS)).resolves.toBeNull();
+  });
+
+  it("returns null when total Stability Pool deposits are zero", async () => {
+    stubBasedollarRpc(DEFAULT_BRANCH_VALUES.map((branch) => ({ ...branch, deposits: 0n })));
+
+    await expect(fetchBasedollarSpSource(undefined, TEST_CHAIN_RPCS)).resolves.toBeNull();
+  });
+});

--- a/worker/src/cron/__tests__/yield-config-registry.test.ts
+++ b/worker/src/cron/__tests__/yield-config-registry.test.ts
@@ -268,19 +268,16 @@ describe("yield config registry", () => {
     }
   });
 
-  it("records the reviewed Base Dollar Stability Pool adapter gap", () => {
+  it("wires the Base Dollar Stability Pool standalone source", () => {
     expect(YIELD_SOURCE_REGISTRY.find((entry) => entry.stablecoinId === "bd-basedollar")).toMatchObject({
-      intentionalGapReason: expect.stringContaining("five branch-specific Liquity V2 Stability Pools"),
+      directProtocolApiLabel: "Base Dollar Stability Pools (interest-only)",
+      directProtocolApiSourceKey: "onchain:bd-basedollar",
     });
-    expect(YIELD_ADAPTER_LIFECYCLE["bd-basedollar"]).toMatchObject({
-      lifecycle: "intentional-gap",
-      reason: expect.objectContaining({
-        code: "source-family-adapter-unimplemented",
-        since: "2026-08-21",
-        nextReviewAt: "2026-09-21",
-      }),
-    });
-    // BD itself is not yield-bearing: the gap concerns an opt-in Stability
+    expect(
+      YIELD_SOURCE_REGISTRY.find((entry) => entry.stablecoinId === "bd-basedollar")?.intentionalGapReason,
+    ).toBeUndefined();
+    expect(YIELD_ADAPTER_LIFECYCLE["bd-basedollar"]).toBeUndefined();
+    // BD itself is not yield-bearing: the source concerns an opt-in Stability
     // Pool opportunity, so it belongs in the source registry rather than the
     // yield-bearing asset manifest.
     expect(YIELD_ADAPTER_MANIFEST.find((entry) => entry.stablecoinId === "bd-basedollar")).toBeUndefined();

--- a/worker/src/cron/yield-config-rate-sources.ts
+++ b/worker/src/cron/yield-config-rate-sources.ts
@@ -285,6 +285,7 @@ export const QUARANTINED_DETERMINISTIC_ADAPTERS: Record<string, string> = Object
 export const DIRECT_PROTOCOL_API_STRATEGIES: Record<string, string> = {
   "scrvusd-curve": "Curve scrvUSD current-rate reader",
   "lusd-liquity": "B.Protocol LQTY-only",
+  "bd-basedollar": "Base Dollar Stability Pools (interest-only)",
   "usbd-bima": "BIMA savings",
   "cetes-etherfuse": "Etherfuse CETES current issuance",
   "usyc-hashnote": "Hashnote NAV feed",
@@ -297,6 +298,7 @@ export const DIRECT_PROTOCOL_API_STRATEGIES: Record<string, string> = {
 export const DIRECT_PROTOCOL_API_SOURCE_KEYS: Record<string, string> = {
   "scrvusd-curve": "onchain:scrvusd-curve:scrvusd-current-rate",
   "lusd-liquity": buildOnChainSourceKey("lusd-liquity"),
+  "bd-basedollar": buildOnChainSourceKey("bd-basedollar"),
   "usbd-bima": "protocol-api:bima-susbd",
   "cetes-etherfuse": "protocol-api:etherfuse-cetes-current-issuance",
   "usyc-hashnote": "protocol-api:hashnote-usyc",
@@ -307,13 +309,6 @@ export const DIRECT_PROTOCOL_API_SOURCE_KEYS: Record<string, string> = {
 };
 
 const INTENTIONAL_GAP_REASONS_TYPED: Record<string, YieldAdapterLifecycleReason> = {
-  "bd-basedollar": {
-    code: "source-family-adapter-unimplemented",
-    since: "2026-08-21",
-    nextReviewAt: "2026-09-21",
-    evidenceUrl: "https://github.com/basedollar/basedollar",
-    note: "2026-08-21 launch review: Base Dollar has five branch-specific Liquity V2 Stability Pools whose variable return combines borrower-fee BD distributions and liquidation collateral gains. Pharos has no reusable multi-branch Liquity V2 Stability Pool realized-return adapter, no yield-bearing wrapper exchange rate, and no verified public machine-readable APY feed. Keep this as an intentional gap until a deterministic adapter snapshots each branch's deposit/reward accumulators, values collateral gains, and aggregates only complete branch coverage.",
-  },
   "bfusd-binance": {
     code: "off-chain-account-product",
     since: "2026-04-14",

--- a/worker/src/cron/yield-sync/sources-optional-protocols-onchain.ts
+++ b/worker/src/cron/yield-sync/sources-optional-protocols-onchain.ts
@@ -3,7 +3,7 @@ import { type ChainRpcConfig, getChainRpc } from "../../lib/chain-registry";
 import { resolveRpcUrls } from "./sources-helpers";
 import { cgHeaders, cgSimplePricePath, cgUrl } from "../../lib/coingecko";
 import { USER_AGENT } from "../../lib/constants";
-import { fetchEvmUint256AtBlock } from "../../lib/evm-rpc";
+import { fetchEvmRpcBatch, fetchEvmUint256AtBlock } from "../../lib/evm-rpc";
 import { fetchJsonWithRetry } from "../../lib/fetch-retry";
 import { throwIfAborted } from "../../lib/abort";
 import { logWorkerEvent } from "../../lib/structured-log";
@@ -20,6 +20,37 @@ const LIQUITY_STABILITY_POOL = "0x66017D22b0f8556afDd19FC67041899Eb65a21bb";
 const LIQUITY_TOTAL_LQTY_ISSUED_SELECTOR = "0xb140384b";
 const LIQUITY_TOTAL_LUSD_DEPOSITS_SELECTOR = "0x9bf2f1ac";
 const LIQUITY_LQTY_GECKO_ID = "liquity";
+const BASEDOLLAR_BD_ID = "bd-basedollar";
+const BASEDOLLAR_SP_SOURCE_LABEL = "Base Dollar Stability Pools (interest-only)";
+const BASEDOLLAR_SP_SOURCE_TYPE = "lending-vault";
+const BASEDOLLAR_COLLATERAL_REGISTRY = "0x7551ebfc8340b7f91874942be9c653733d4fb04f";
+const BASEDOLLAR_TOTAL_COLLATERALS_SELECTOR = "0x30504b6f";
+const BASEDOLLAR_AGG_WEIGHTED_DEBT_SUM_SELECTOR = "0x42635a95";
+const BASEDOLLAR_SHUTDOWN_TIME_SELECTOR = "0x58569081";
+const BASEDOLLAR_TOTAL_BOLD_DEPOSITS_SELECTOR = "0xf71c6940";
+const BASEDOLLAR_SP_YIELD_SPLIT_PERCENT = 75n;
+const BASEDOLLAR_BRANCHES = [
+  {
+    activePool: "0x254a8267d4e12a8c0f283274632a18a33e49f7c0",
+    stabilityPool: "0x7d837bf114785642d225d1101145ddb8af4ba438",
+  },
+  {
+    activePool: "0x1021fefc406c9573ab3579fc55be13e3300ef6b1",
+    stabilityPool: "0xc65a05737d31e0f42c0806c739f3c88dd009c05f",
+  },
+  {
+    activePool: "0x1b9a62798e8bae0cea4eb21b4b3775359beb819f",
+    stabilityPool: "0x4eb3b6970fd358d34195b5d40e4eb64e0e3c0b6a",
+  },
+  {
+    activePool: "0xcaa72df531554087318eaf24646958500668b230",
+    stabilityPool: "0x6bd55dd953507641c84a03956760f83d29d65726",
+  },
+  {
+    activePool: "0xddac84ab417677f553cced8ababf497226112218",
+    stabilityPool: "0x25afbb09d9804482ed8e24295be4a12704fe93ea",
+  },
+] as const;
 const SCRVUSD_VAULT = "0x0655977FEb2f289A4aB78af67BAB0d17aAb84367";
 const SCRVUSD_CURRENT_RATE_SOURCE_KEY = "onchain:scrvusd-curve:scrvusd-current-rate";
 const SCRVUSD_SOURCE_POOL = "5fd328af-4203-471b-bd16-1705c726d926";
@@ -197,6 +228,126 @@ export async function fetchBprotocolLqtyOnlySource(
       level: "warn",
       event: "bprotocol-source-failed",
       message: "B.Protocol LQTY-only source failed",
+      error,
+    });
+    return null;
+  }
+}
+
+export async function fetchBasedollarSpSource(
+  signal?: AbortSignal,
+  chainRpcs?: Map<string, ChainRpcConfig>,
+): Promise<ResolvedYield | null> {
+  if (!chainRpcs) {
+    logWorkerEvent({
+      scope: "lib",
+      job: "sync-yield-data",
+      level: "warn",
+      event: "basedollar-rpcs-missing",
+      message: "No chain RPCs provided for Base Dollar Stability Pool source",
+    });
+    return null;
+  }
+  const rpc = getChainRpc(chainRpcs, "base");
+  if (!rpc) {
+    logWorkerEvent({
+      scope: "lib",
+      job: "sync-yield-data",
+      level: "warn",
+      event: "basedollar-base-rpc-missing",
+      message: "No Base RPC configured for Base Dollar Stability Pool source",
+    });
+    return null;
+  }
+
+  try {
+    // One JSON-RPC batch keeps every read on a single provider snapshot: the
+    // registry branch count plus the three per-branch reads. The count guard
+    // fails closed if the collateral governor registers a branch this adapter
+    // does not yet aggregate (AERO / Aerodrome LP branches are announced), so
+    // a partial sum can never publish as a "complete" APR.
+    const calls = [
+      {
+        method: "eth_call",
+        params: [{ to: BASEDOLLAR_COLLATERAL_REGISTRY, data: BASEDOLLAR_TOTAL_COLLATERALS_SELECTOR }, "latest"],
+      },
+      ...BASEDOLLAR_BRANCHES.flatMap((branch) => [
+        { method: "eth_call", params: [{ to: branch.activePool, data: BASEDOLLAR_AGG_WEIGHTED_DEBT_SUM_SELECTOR }, "latest"] },
+        { method: "eth_call", params: [{ to: branch.activePool, data: BASEDOLLAR_SHUTDOWN_TIME_SELECTOR }, "latest"] },
+        { method: "eth_call", params: [{ to: branch.stabilityPool, data: BASEDOLLAR_TOTAL_BOLD_DEPOSITS_SELECTOR }, "latest"] },
+      ]),
+    ];
+
+    throwIfAborted(signal);
+    const results = await fetchEvmRpcBatch("base", calls, { chainRpcs, signal });
+    if (results === null) return null;
+
+    const values: bigint[] = [];
+    for (const result of results) {
+      if (typeof result !== "string" || !/^0x[0-9a-fA-F]+$/.test(result)) return null;
+      values.push(BigInt(result));
+    }
+
+    const totalCollaterals = values[0]!;
+    if (totalCollaterals !== BigInt(BASEDOLLAR_BRANCHES.length)) {
+      logWorkerEvent({
+        scope: "lib",
+        job: "sync-yield-data",
+        level: "warn",
+        event: "basedollar-branch-count-mismatch",
+        message:
+          `Base Dollar CollateralRegistry reports ${totalCollaterals} branches but the adapter aggregates ` +
+          `${BASEDOLLAR_BRANCHES.length}; failing closed until the branch table is re-reviewed`,
+      });
+      return null;
+    }
+
+    let totalAggWeightedDebtSumRaw = 0n;
+    let totalDepositsRaw = 0n;
+    for (let index = 0; index < BASEDOLLAR_BRANCHES.length; index += 1) {
+      const aggWeightedDebtSumRaw = values[1 + index * 3]!;
+      const shutdownTimeRaw = values[2 + index * 3]!;
+      const depositsRaw = values[3 + index * 3]!;
+      // A shut-down branch accrues no interest; its deposits stay in the denominator.
+      if (shutdownTimeRaw === 0n) {
+        totalAggWeightedDebtSumRaw += aggWeightedDebtSumRaw;
+      }
+      totalDepositsRaw += depositsRaw;
+    }
+
+    if (totalDepositsRaw <= 0n) return null;
+
+    // APR% = 75 * sum(aggWeightedDebtSum) / (sum(SP deposits) * 1e18).
+    // This is interest-only: upfront borrowing fees and liquidation collateral gains are excluded.
+    const apr =
+      Number(BASEDOLLAR_SP_YIELD_SPLIT_PERCENT * totalAggWeightedDebtSumRaw)
+      / Number(totalDepositsRaw * 10n ** 18n);
+    const totalDeposits = Number(totalDepositsRaw) / 1e18;
+    if (!Number.isFinite(totalDeposits) || totalDeposits <= 0) return null;
+    if (!Number.isFinite(apr) || apr <= 0) return null;
+
+    return {
+      currentApy: apr,
+      apyBase: apr,
+      apyReward: null,
+      sourcePool: null,
+      sourceTvlUsd: totalDeposits,
+      dataSource: "onchain",
+      exchangeRate: null,
+      sourceKey: buildOnChainSourceKey(BASEDOLLAR_BD_ID),
+      yieldSource: BASEDOLLAR_SP_SOURCE_LABEL,
+      yieldType: BASEDOLLAR_SP_SOURCE_TYPE,
+    };
+  } catch (error) {
+    if (signal?.aborted) {
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+    logWorkerEvent({
+      scope: "lib",
+      job: "sync-yield-data",
+      level: "warn",
+      event: "basedollar-source-failed",
+      message: "Base Dollar Stability Pool source failed",
       error,
     });
     return null;

--- a/worker/src/cron/yield-sync/sources-optional-protocols.ts
+++ b/worker/src/cron/yield-sync/sources-optional-protocols.ts
@@ -1,4 +1,5 @@
 export {
+  fetchBasedollarSpSource,
   fetchBprotocolLqtyOnlySource,
   fetchCurveScrvusdCurrentRateSource,
 } from "./sources-optional-protocols-onchain";

--- a/worker/src/cron/yield-sync/sources.ts
+++ b/worker/src/cron/yield-sync/sources.ts
@@ -1,6 +1,7 @@
 export {
   fetchBeefySources,
   fetchBimaSusbdSource,
+  fetchBasedollarSpSource,
   fetchBprotocolLqtyOnlySource,
   fetchCurveScrvusdCurrentRateSource,
   fetchEtherfuseCetesSource,

--- a/worker/src/cron/yield-sync/tracked-optional-source-registry.ts
+++ b/worker/src/cron/yield-sync/tracked-optional-source-registry.ts
@@ -1,6 +1,7 @@
 import { DAY_SECONDS } from "@shared/lib/time-constants";
 import { buildOnChainSourceKey } from "../yield-helpers";
 import {
+  fetchBasedollarSpSource,
   fetchBimaSusbdSource,
   fetchBprotocolLqtyOnlySource,
   fetchCurveScrvusdCurrentRateSource,
@@ -16,6 +17,7 @@ import type { ResolvedYield } from "./types";
 import type { ChainRpcConfig } from "../../lib/chain-registry";
 
 const LIQUITY_V1_LUSD_ID = "lusd-liquity";
+const BASEDOLLAR_BD_ID = "bd-basedollar";
 const SCRVUSD_CURVE_ID = "scrvusd-curve";
 const BIMA_USBD_ID = "usbd-bima";
 const CETES_ETHERFUSE_ID = "cetes-etherfuse";
@@ -226,6 +228,20 @@ export const STANDALONE_TRACKED_OPTIONAL_SOURCE_REGISTRY: readonly TrackedOption
           budgetSignal,
           context.chainRpcs,
           context.coingeckoApiKey,
+        ),
+        null,
+      ),
+  },
+  {
+    stablecoinId: BASEDOLLAR_BD_ID,
+    sourceKey: buildOnChainSourceKey(BASEDOLLAR_BD_ID),
+    run: (context) =>
+      runTimedOptionalSource(
+        "Base Dollar SP interest-only source",
+        context.signal,
+        (budgetSignal) => fetchBasedollarSpSource(
+          budgetSignal,
+          context.chainRpcs,
         ),
         null,
       ),


### PR DESCRIPTION
## Summary
- add the Base Dollar Liquity V2 Stability Pool yield source and registry coverage
- add Base Dollar compliance sidecar data for MiCA out-of-scope and GENIUS unclear status
- update yield methodology/API docs, changelog metadata, and the V9 evaluation manifest generated by the BD integration

## Validation
- npm run check:pr -- --base=origin/main

Local note: the worktree has unrelated unstaged stablecoin-detail UI/design edits; they are not part of this branch or PR.