### PR TITLE
fix: keep V9 attribution below the Worker memory ceiling

### DIFF
--- a/scripts/lib/night-watch-registry-fixture.json
+++ b/scripts/lib/night-watch-registry-fixture.json
@@ -33,6 +33,7 @@
     "cron-staleness-watchdog",
     "daily-digest",
     "data-invariant-canary",
+    "dex-exit-route-turnover-watchdog",
     "dispatch-telegram-alerts",
     "fetch-tbill-rate",
     "mint-burn-growth-watchdog",


### PR DESCRIPTION
## Summary
- run the RPC-heavy V9 supply-attribution capture before lazily loading DDR's large review graph in their shared isolate
- preserve serial execution and the existing 3/6 connection peak while preventing the confirmed attribution exceededMemory failure
- enroll the new exit-route watchdog in the explicit Night Watch registry fixture
- update the Worker limit contract for the new memory-safe ordering

## Production evidence
- Worker analytics recorded one exceededMemory invocation at 2026-08-21T17:23:02Z
- the matching v9SupplyAttributionOffset slot stranded after DDR completed and attribution acquired its lease
- all other post-deploy high-risk lanes completed without errors, including sync-yield-data in 182 seconds

## Validation
- focused V9 scheduling/producer/source suites: 3 files, 8 tests passed
- worker TypeScript check
- cron schedule and connection-budget checks
- generated-artifact convergence
- Night Watch dry-run registry validation
- git diff --check

## Acceptance
Observe a clean v9SupplyAttributionOffset execution after deployment and confirm Cloudflare reports no new exceededMemory outcome.