### PR TITLE
fix(v9): restore publication after reserve-weight rounding drift

### DIFF
--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -30,7 +30,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/dependency-derivation.ts",
-      "sha256": "8ca1edc6d8eb69590fcd9d5301b82b0967c129e03e0fea110b00f35322267d10"
+      "sha256": "a0c32d8cd439a0d13588efd6e9233cceae0451d5de66b94e662b54470d83e6ea"
     },
     {
       "path": "shared/lib/dependency-graph.ts",
@@ -537,7 +537,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "f1562d9bdf8db70336973b7ac7ad3ab639a0d16db943b9a9d03a92cb91616b6c"
     }
   ],
-  "digest": "41892c6e616d10a2e183d10d17f7c1adad1a76c6633803a7537ddacd0541df9a"
+  "digest": "ec59e9e809c7a15284c14cf4477f8e1ca668f8f6042704fcf0472528b9ceb5dd"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/lib/__tests__/dependency-graph.test.ts
+++ b/shared/lib/__tests__/dependency-graph.test.ts
@@ -123,6 +123,35 @@ describe("dependency-graph", () => {
     expect(dependencies).toEqual([{ id: "live-upstream", weight: 0.4, type: "collateral" }]);
   });
 
+  it("canonicalizes machine-precision drift for an exact full-weight live reserve basket", () => {
+    const result = deriveEffectiveDependencySet(makeMeta({ id: "dependent" }), {
+      liveReserveSlices: [
+        { name: "sfrxUSD", pct: 37.976681, risk: "medium", coinId: "sfrxusd-frax" },
+        { name: "sUSDe", pct: 37.173171, risk: "medium", coinId: "susde-ethena" },
+        { name: "ygamiUSDC", pct: 12.235688, risk: "high", coinId: "usdc-circle" },
+        { name: "sUSDS", pct: 11.924473, risk: "low", coinId: "susds-sky" },
+        { name: "USDe", pct: 0.657631, risk: "medium", coinId: "usde-ethena" },
+        { name: "USDC", pct: 0.024855, risk: "low", coinId: "usdc-circle" },
+        { name: "frxUSD", pct: 0.006503, risk: "low", coinId: "frxusd-frax" },
+        { name: "USDS", pct: 0.000998, risk: "low", coinId: "usds-sky" },
+      ],
+    });
+
+    expect(result.dependencies.reduce((sum, dependency) => sum + dependency.weight, 0)).toBeGreaterThan(1);
+    expect(result.mappedLiveReserveWeight).toBe(1);
+  });
+
+  it("preserves material live reserve overweights for fail-closed validation", () => {
+    const result = deriveEffectiveDependencySet(makeMeta({ id: "dependent" }), {
+      liveReserveSlices: [
+        { name: "Upstream A", pct: 60, risk: "low", coinId: "upstream-a" },
+        { name: "Upstream B", pct: 40.001, risk: "low", coinId: "upstream-b" },
+      ],
+    });
+
+    expect(result.mappedLiveReserveWeight).toBeCloseTo(1.00001, 12);
+  });
+
   it("falls back to curated dependencies when live reserve slices have no tracked upstreams", () => {
     const dependencies = deriveEffectiveDependencies(
       makeMeta({

--- a/shared/lib/dependency-derivation.ts
+++ b/shared/lib/dependency-derivation.ts
@@ -47,7 +47,16 @@ function aggregateReserveDependencies(
 }
 
 function sumDependencyWeight(dependencies: readonly DependencyWeight[]): number {
-  return dependencies.reduce((sum, dependency) => sum + dependency.weight, 0);
+  const total = dependencies.reduce((sum, dependency) => sum + dependency.weight, 0);
+
+  // Reserve adapters publish decimal percentages. Converting each slice to a
+  // fraction before summing can put an exact 100% basket one ULP above 1,
+  // which is not a real overweight condition but is outside FractionSchema.
+  // Canonicalize only negligible boundary drift; material overweights remain
+  // visible to the dependency validator and fail closed.
+  if (Math.abs(total) <= 1e-12) return 0;
+  if (Math.abs(total - 1) <= 1e-12) return 1;
+  return total;
 }
 
 function injectVariantParent(


### PR DESCRIPTION
## Summary
- canonicalize machine-precision drift at dependency fraction boundaries
- preserve material reserve overweights for fail-closed validation
- add the exact production USDP reserve composition as a regression
- refresh the pinned Safety Score V9 evaluation-build manifest

## Production incident
An exact 100% live-reserve basket for usdp-parallel summed to 1.0000000000000002. The dependency graph tolerated that one-ULP arithmetic artifact, but the publication schema rejected mappedLiveReserveWeight above 1, causing repeated V9 compilation failures. That stale V9 source cascaded into the Telegram degradation watchdog warning.

## Validation
- npm run check:pr -- --base=origin/main
- 71 selected test files passed; 1,003 tests passed and 1 skipped
- npm run check:generated-artifacts
- focused V9 publication suite: 78 tests passed