### PR TITLE
fix(watchdog): exclude producers beyond cron_runs retention

### DIFF
--- a/worker/src/cron/__tests__/cron-staleness-watchdog.test.ts
+++ b/worker/src/cron/__tests__/cron-staleness-watchdog.test.ts
@@ -120,6 +120,19 @@ describe("cron staleness watchdog", () => {
       }));
   });
 
+  it("excludes producers whose staleness threshold exceeds cron_runs retention", () => {
+    // A monthly cadence (3x interval = 90d) can never be proven fresh from
+    // week-retained cron_runs rows; monitoring it would alert forever.
+    const monthly = {
+      ...CRON_JOB_DEFINITIONS[0],
+      job: "yield-coverage-audit-like",
+      intervalSec: 30 * 24 * 3600,
+    };
+    const producers = deriveCronFreshnessProducers([...CRON_JOB_DEFINITIONS, monthly]);
+    expect(producers.map((producer) => producer.producerJob)).not.toContain("yield-coverage-audit-like");
+    expect(producers.map((producer) => producer.producerJob)).not.toContain("yield-coverage-audit");
+  });
+
   it("flags watched freshness lanes beyond twice their producer interval", () => {
     expect(evaluateCronStaleness({
       stablecoins: { ageSeconds: 1_801 }, "fx-rates": { ageSeconds: 1_799 }, "dex-liquidity": { ageSeconds: 14_401 }, "yield-data": { ageSeconds: 3_600 }, dews: { ageSeconds: 1_000 },

--- a/worker/src/cron/cron-staleness-watchdog.ts
+++ b/worker/src/cron/cron-staleness-watchdog.ts
@@ -36,6 +36,13 @@ const NO_CONSUMER_FRESHNESS_SURFACE_JOBS = new Set([
   "telegram-retention-cleanup",
 ]);
 
+// Registry-derived lanes prove freshness from cron_runs MAX(started_at), and
+// prune-cron-history deletes cron_runs rows older than one week. A producer
+// whose 3x-interval staleness threshold exceeds that retention (e.g. the
+// monthly yield-coverage-audit) can never be observed fresh here and would
+// alert forever; such cadences need their own audit trail, not this watchdog.
+const CRON_RUNS_OBSERVABILITY_RETENTION_SEC = 7 * 24 * 3600;
+
 const WATCHDOG_STATE_KEY = "cron-staleness-watchdog:producer-state:v1";
 const WATCHDOG_ALERT_KEY = "cron-staleness-watchdog:alert:direct:v1";
 export const CRON_STALENESS_ALERT_COOLDOWN_SEC = 30 * 60;
@@ -69,6 +76,7 @@ export function deriveCronFreshnessProducers(
         thresholdSec: cacheLane.lane.producerIntervalSec * 2,
       }];
     }
+    if (definition.intervalSec * 3 > CRON_RUNS_OBSERVABILITY_RETENTION_SEC) return [];
     return [{
       producerJob: definition.job,
       laneKey: null,


### PR DESCRIPTION
Operational follow-up to #926: the first production run of the registry-derived staleness watchdog permanently flagged the monthly yield-coverage-audit (3x-interval threshold 90d > 7d cron_runs retention; ageSeconds null; one false operator alert at 18:25Z). Registry-derived lanes now structurally exclude producers whose threshold exceeds the retention window, with a regression test. The next watchdog run after deploy should emit a single recovery transition and return to ok.