### PR TITLE
fix(v9): restore Safety Score publication rollover

### DIFF
--- a/scripts/__tests__/fixtures/markdown/changelog-index.md
+++ b/scripts/__tests__/fixtures/markdown/changelog-index.md
@@ -6,6 +6,18 @@ description: "Weekly release notes for Pharos."
 
 # Changelog
 
+## 2026-08-17 to 2026-08-23
+
+The Safety Score map ships daily, Liquidity Score v6 lands, and the yield surface stops blanking.
+
+- **Daily Safety Score map**: The shareable Safety Score landscape became a daily 07:20 UTC publication, generated behind fail-closed guards for stale data, join coverage, font loading, and layout collisions, and it rides the social digest.
+- **Safety Score V9 stability**: V9 advanced from v9.23 to v9.33: the mint-authority and bridge-risk boundary closed its fail-open, Solana attribution anchors hardened, reserve-weight boundary drift was canonicalized, and curation entries now expire.
+- **Liquidity Score v6**: The v6.0 cutover corrected a Raydium double count that scored concentrated pools as plain AMMs, retired the native lane, and deleted the shadow inventory. v6.1 scopes native confirmation to covered pool families.
+- **Yield availability**: Yield rankings now fall back to the coherent publish-time safety snapshot instead of blanking scores after every scoring deploy, with an explicit stale label and a 24-hour window. Base Dollar yield joined at v8.41.
+- **Scheduler reliability**: Reserve interruption recovery left shadow mode, transient D1 transport loss became retriable, CPU-heavy quarter-hour lanes moved to the hourly class, and DDR now runs before V9 attribution to keep both inside the heap.
+- **Broader coverage**: Base Dollar was promoted to active with a verified Base deployment, Aerodrome price discovery, and a documented mint-authorization path. Reflexer's RAI Dollar joined as pre-launch, taking the tracked catalog to 405.
+- **Repository health**: A simplification wave drained 15k lines of duplication, a repository review closed four P0 correctness defects and hardened the Worker, and structured data stopped advertising a credentialed endpoint as a public download.
+
 ## 2026-08-10 to 2026-08-16
 
 MiCA and GENIUS backfilled across 322 coins, redemption reaches 327 routes, and the V9 stack is rebuilt.

--- a/src/data/changelogs/2026-08-23.ts
+++ b/src/data/changelogs/2026-08-23.ts
@@ -1,0 +1,79 @@
+import type { ChangelogEntry } from "./types";
+
+export const entry: ChangelogEntry = {
+  dateRange: { from: "2026-08-17", to: "2026-08-23" },
+  headline:
+    "The Safety Score map ships daily, Liquidity Score v6 lands, and the yield surface stops blanking.",
+  fieldNotes:
+    "A week of turning fragile things into scheduled ones. The Safety Score landscape stopped being a manual monthly artifact and became a guarded daily publication that rides along with the social digest. Liquidity Score v6 completed its staged cutover, correcting a Raydium double count that had been quietly inflating depth. Most of the remaining effort went where it usually goes after a busy month: cron lanes, memory ceilings, and the duplication that accumulates when everything ships at once.",
+  summary: [
+    {
+      label: "Daily Safety Score map",
+      tag: "feature",
+      description:
+        "The shareable Safety Score landscape became a daily 07:20 UTC publication, generated behind fail-closed guards for stale data, join coverage, font loading, and layout collisions, and it rides the social digest.",
+    },
+    {
+      label: "Safety Score V9 stability",
+      tag: "feature",
+      description:
+        "V9 advanced from v9.23 to v9.33: the mint-authority and bridge-risk boundary closed its fail-open, Solana attribution anchors hardened, reserve-weight boundary drift was canonicalized, and curation entries now expire.",
+      href: "/methodology/scoring-changelog",
+    },
+    {
+      label: "Liquidity Score v6",
+      tag: "feature",
+      description:
+        "The v6.0 cutover corrected a Raydium double count that scored concentrated pools as plain AMMs, retired the native lane, and deleted the shadow inventory. v6.1 scopes native confirmation to covered pool families.",
+      href: "/methodology/liquidity-score-changelog",
+    },
+    {
+      label: "Yield availability",
+      tag: "feature",
+      description:
+        "Yield rankings now fall back to the coherent publish-time safety snapshot instead of blanking scores after every scoring deploy, with an explicit stale label and a 24-hour window. Base Dollar yield joined at v8.41.",
+      href: "/methodology/yield-changelog",
+    },
+    {
+      label: "Scheduler reliability",
+      tag: "infra",
+      description:
+        "Reserve interruption recovery left shadow mode, transient D1 transport loss became retriable, CPU-heavy quarter-hour lanes moved to the hourly class, and DDR now runs before V9 attribution to keep both inside the heap.",
+    },
+    {
+      label: "Broader coverage",
+      tag: "coverage",
+      description:
+        "Base Dollar was promoted to active with a verified Base deployment, Aerodrome price discovery, and a documented mint-authorization path. Reflexer's RAI Dollar joined as pre-launch, taking the tracked catalog to 405.",
+    },
+    {
+      label: "Repository health",
+      tag: "infra",
+      description:
+        "A simplification wave drained 15k lines of duplication, a repository review closed four P0 correctness defects and hardened the Worker, and structured data stopped advertising a credentialed endpoint as a public download.",
+    },
+  ],
+  stats: { totalCommits: 45 },
+  commits: [
+    { hash: "b394abd7", message: "Code simplification wave: -15k LOC of duplication, plus the SEO batch (#930)" },
+    { hash: "8acea310", message: "fix(snapshot-supply): restored-only ids no longer veto the daily snapshot (#928)" },
+    { hash: "a4fb5cdb", message: "fix(watchdog): exclude producers beyond cron_runs retention from freshness lanes (#927)" },
+    { hash: "670ed6d5", message: "Repository review implementation: P0 correctness, data fail-closed, worker hardening, consolidation (#926)" },
+    { hash: "34200751", message: "Bound V9 publication compiler memory (#925)" },
+    { hash: "8ef00a63", message: "fix(digest): stop unverified DEX liquidity artifacts from leading the digest (#924)" },
+    { hash: "6bd2501c", message: "fix(v9): canonicalize reserve-weight boundary drift (#923)" },
+    { hash: "b7a71e7a", message: "feat(digest): attach daily safety map to social posts" },
+    { hash: "8786e3a5", message: "fix(cron): move CPU-heavy quarter-hour lanes to the hourly Cron CPU class (#921)" },
+    { hash: "c8a21c96", message: "fix(v9): harden Solana attribution anchors" },
+    { hash: "e8e4ff04", message: "fix(cron): stabilize distressed production lanes (#919)" },
+    { hash: "07290bed", message: "fix(pricing): preserve fallback cursor fairness" },
+    { hash: "93bb715c", message: "test(ci): restore Nightly type validation" },
+    { hash: "cbd39e57", message: "fix(cron): harden distressed production lanes" },
+    { hash: "74ca9d2b", message: "fix(worker): capture V9 attribution before DDR heap work (#918)" },
+    { hash: "393984d0", message: "fix(ops): enroll exit-route watchdog in night watch (#917)" },
+    { hash: "3f481cd5", message: "fix: restore production scheduler health and stabilize Safety Score V9 (#916)" },
+    { hash: "26b56753", message: "Add Base Dollar yield and compliance coverage (#915)" },
+    { hash: "fdd568e8", message: "fix(cron): run DDR before V9 attribution (#914)" },
+    { hash: "c432e514", message: "ci(safety-map): enable the daily 07:20 UTC schedule (#913)" },
+  ],
+};

--- a/src/data/changelogs/index.ts
+++ b/src/data/changelogs/index.ts
@@ -24,6 +24,7 @@ import { entry as e20260727 } from "./2026-07-27";
 import { entry as e20260802 } from "./2026-08-02";
 import { entry as e20260809 } from "./2026-08-09";
 import { entry as e20260816 } from "./2026-08-16";
+import { entry as e20260823 } from "./2026-08-23";
 
 const all: ChangelogEntry[] = [
   e20260308,
@@ -50,6 +51,7 @@ const all: ChangelogEntry[] = [
   e20260802,
   e20260809,
   e20260816,
+  e20260823,
 ];
 
 export const changelogs: ChangelogEntry[] = all.sort(

--- a/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
@@ -2,7 +2,11 @@ import { stableJsonStringifyV1 } from "@shared/lib/stable-json";
 import { createHash } from "node:crypto";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
-import { makeWorkerSafetyScoreV9Publication } from "../../test-helpers/report-cards-v9";
+import {
+  makeWorkerSafetyScoreV9Publication,
+  makeWorkerV9Card,
+  makeWorkerV9Pillars,
+} from "../../test-helpers/report-cards-v9";
 import {
   parseSafetyScoreV9Publication,
   serializeSafetyScoreV9Publication,
@@ -38,6 +42,58 @@ describe("Safety Score V9 publication codec", () => {
         stressStateDigest: "a".repeat(64),
       })),
     });
+    const compressed = gzipSync(Buffer.from(legacyPayload));
+    const stored = stableJsonStringifyV1({
+      ...envelope,
+      payloadSha256: createHash("sha256").update(legacyPayload).digest("hex"),
+      uncompressedBytes: Buffer.byteLength(legacyPayload),
+      compressedBytes: compressed.byteLength,
+      payload: compressed.toString("base64"),
+    });
+
+    await expect(parseSafetyScoreV9Publication(stored)).resolves.toEqual(
+      publication,
+    );
+  });
+
+  it("reads an authenticated V5 publication emitted before NR binding caps were suppressed", async () => {
+    const cap = {
+      kind: "reason:missing-reserve-composition",
+      limit: 55,
+      source: "evidence" as const,
+      reason: "Reserve composition is unavailable.",
+      binding: true,
+    };
+    const publication = makeWorkerSafetyScoreV9Publication({
+      cards: [
+        makeWorkerV9Card({
+          score: null,
+          grade: "NR",
+          qualityScore: null,
+          pegMultiplier: null,
+          pegAdjustedScore: null,
+          pillars: makeWorkerV9Pillars({ backing: null, exit: null, control: null }),
+          caps: [{ ...cap, binding: false }],
+          bindingCap: null,
+          nrReasons: [{
+            code: "missing-reserve-composition",
+            field: "pillars.backing",
+            message: "Reserve composition is unavailable.",
+            origin: "asset",
+          }],
+          reasonCodes: ["missing-reserve-composition"],
+        }),
+      ],
+    });
+    const envelope = JSON.parse(
+      await serializeSafetyScoreV9Publication(publication),
+    ) as Record<string, unknown>;
+    const legacyPublication = JSON.parse(
+      gunzipSync(Buffer.from(String(envelope.payload), "base64")).toString("utf8"),
+    ) as typeof publication;
+    legacyPublication.cards[0]!.caps = [cap];
+    legacyPublication.cards[0]!.bindingCap = cap;
+    const legacyPayload = stableJsonStringifyV1(legacyPublication);
     const compressed = gzipSync(Buffer.from(legacyPayload));
     const stored = stableJsonStringifyV1({
       ...envelope,

--- a/worker/src/lib/safety-score-v9-publication-codec.ts
+++ b/worker/src/lib/safety-score-v9-publication-codec.ts
@@ -124,18 +124,19 @@ function parsePublicationPayload(
     throw new Error(`${label} JSON is not canonical`);
   }
   return SafetyScoreV9CurrentResponseSchema.parse(
-    withoutRetiredStressStateDigests(parsed.value),
+    normalizeRetiredCardFields(parsed.value),
   );
 }
 
 /**
- * Methodology 9.15 retired this unused card field without changing the V5
- * envelope version. Keep the storage reader able to cross that one-field
- * boundary so the first 9.15 candidate can compare with and replace the last
- * 9.14 publication. Integrity checks still cover the original stored bytes;
- * only the already-authenticated payload is normalized for the current schema.
+ * Methodology 9.15 retired `stressStateDigest`, and 9.35 stopped publishing a
+ * binding cap on NR cards, without changing the V5 envelope version. Keep the
+ * storage reader able to cross those card-field boundaries so a new candidate
+ * can compare with and replace the last accepted publication. Integrity checks
+ * still cover the original stored bytes; only the already-authenticated payload
+ * is normalized for the current schema.
  */
-function withoutRetiredStressStateDigests(value: unknown): unknown {
+function normalizeRetiredCardFields(value: unknown): unknown {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return value;
   }
@@ -147,16 +148,41 @@ function withoutRetiredStressStateDigests(value: unknown): unknown {
       return card;
     }
     const record = card as Record<string, unknown>;
-    if (!("stressStateDigest" in record)) return card;
-    const digest = record.stressStateDigest;
-    if (
-      digest !== null &&
-      (typeof digest !== "string" || !/^[a-f0-9]{64}$/.test(digest))
-    ) {
-      throw new Error("Retired Safety Score v9 stress state digest is invalid");
+    let currentCard = record;
+    if ("stressStateDigest" in currentCard) {
+      const digest = currentCard.stressStateDigest;
+      if (
+        digest !== null &&
+        (typeof digest !== "string" || !/^[a-f0-9]{64}$/.test(digest))
+      ) {
+        throw new Error("Retired Safety Score v9 stress state digest is invalid");
+      }
+      const { stressStateDigest: _retired, ...withoutStressStateDigest } = currentCard;
+      currentCard = withoutStressStateDigest;
+      changed = true;
     }
-    const { stressStateDigest: _retired, ...currentCard } = record;
-    changed = true;
+
+    if (
+      currentCard.score === null &&
+      (currentCard.bindingCap !== null ||
+        (Array.isArray(currentCard.caps) &&
+          currentCard.caps.some(
+            (cap) => cap !== null && typeof cap === "object" && !Array.isArray(cap) && cap.binding === true,
+          )))
+    ) {
+      currentCard = {
+        ...currentCard,
+        bindingCap: null,
+        caps: Array.isArray(currentCard.caps)
+          ? currentCard.caps.map((cap) =>
+              cap !== null && typeof cap === "object" && !Array.isArray(cap)
+                ? { ...cap, binding: false }
+                : cap,
+            )
+          : currentCard.caps,
+      };
+      changed = true;
+    }
     return currentCard;
   });
   return changed ? { ...publication, cards } : value;


### PR DESCRIPTION
## Summary\n- publish the pending weekly changelog\n- normalize authenticated pre-9.35 NR binding-cap assertions while loading the last accepted V5 Safety Score publication\n- keep new V9 publications under the stricter NR-cap schema\n- add a compressed-envelope regression matching the production rollover failure\n\n## Production incident\nThe 9.35 Worker is active, but each V9 compiler attempt fails before replacement because loading the last accepted publication raises `An NR result cannot carry a binding cap`. This leaves `report-cards:v9` unavailable, degrades the invariant canary and yield safety identity, and empties `/safety-scores`.\n\n## Validation\n- `npx vitest run worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts worker/src/lib/__tests__/safety-score-v9-publication-runner.test.ts worker/src/lib/__tests__/safety-score-v9-publication-store.test.ts shared/lib/__tests__/safety-score-v9-public-nr-cap-suppression.test.ts`\n- `npm run typecheck:worker`\n- `npm run check:generated-artifacts`\n- `npm run check:pr -- --base=origin/main` (128 files, 1,731 tests)\n- `git diff --check`