### PR TITLE
fix(safety-map): fit poster metadata within SEO limit

### DIFF
--- a/src/app/safety-scores/map/page.tsx
+++ b/src/app/safety-scores/map/page.tsx
@@ -12,7 +12,7 @@ import { SafetyMapPoster } from "./poster";
 export const metadata: Metadata = buildPageMetadata({
   title: "Stablecoin Safety Map: All Graded Coins by Tier",
   description:
-    "A downloadable poster of every stablecoin Pharos grades, drawn across five discrete A-to-F grade bands with supply-proportional area above per-tier minimum markers and fixed presence markers below.",
+    "A downloadable poster of every stablecoin Pharos grades, arranged across five A-to-F bands with bubble area tracking circulating supply and fixed markers for smaller assets.",
   canonical: "/safety-scores/map/",
   // The poster itself is served from KV by a Pages Function, so it is not a file
   // in `out/` and cannot be a same-origin og:image. Use the dynamic Safety


### PR DESCRIPTION
## Summary
- shorten the Safety Map meta description below the 180-character SEO ceiling
- preserve the grade-band, supply-area, and small-asset marker context
- unblock the Pages release for the completed Safety Map work

## Validation
- `npm run build`
- `npm run seo:check` (1,249 HTML pages passed)
- `git diff --check`

## Release context
Follow-up to #938. Worker deployment for main SHA `7dfb1fa9` succeeded, while Pages stopped before publish on the metadata-length gate.