### PR TITLE
fix(safety-scores): read publications written before the sixth responsibility owner

### DIFF
--- a/shared/types/__tests__/safety-score-v9-public.test.ts
+++ b/shared/types/__tests__/safety-score-v9-public.test.ts
@@ -330,7 +330,7 @@ function adjustedResponse(): MutableAdjustedResponseFixture {
 }
 
 describe("SafetyScoreV9ResponseSchema", () => {
-  it("accepts pre-9.19 snapshots without per-fact disclosure paths", () => {
+  it("accepts stored snapshots that predate the sixth responsibility owner", () => {
     const legacy = currentResponse();
     const trace = legacy.cards[0]!.scoreTrace!;
     delete trace.evidenceResponsibility.facts;
@@ -339,10 +339,21 @@ describe("SafetyScoreV9ResponseSchema", () => {
     expect(parsed.cards[0]?.scoreTrace.evidenceResponsibility.facts).toBeUndefined();
     expect(parsed.cards[0]?.scoreTrace.evidenceResponsibility.summaries).toHaveLength(5);
 
-    const incompleteCurrent = currentResponse();
-    incompleteCurrent.cards[0]!.scoreTrace!.evidenceResponsibility.summaries.pop();
-    expect(() => SafetyScoreV9CurrentResponseSchema.parse(incompleteCurrent)).toThrow(
-      /must cover every owner in canonical order/,
+    // Per-fact paths (9.19) and the sixth owner (9.4) arrived separately, so a
+    // stored publication can carry `facts` and still predate the owner. Reading
+    // that shape is what the 9.4 release initially got wrong.
+    const factsWithLegacyOwners = currentResponse();
+    factsWithLegacyOwners.cards[0]!.scoreTrace!.evidenceResponsibility.summaries.pop();
+    const parsedWithFacts = SafetyScoreV9CurrentResponseSchema.parse(factsWithLegacyOwners);
+    expect(parsedWithFacts.cards[0]?.scoreTrace.evidenceResponsibility.facts).toBeDefined();
+    expect(parsedWithFacts.cards[0]?.scoreTrace.evidenceResponsibility.summaries).toHaveLength(5);
+
+    // A non-canonical owner set is still refused: dropping an interior owner is
+    // corruption, not an older writer.
+    const nonCanonical = currentResponse();
+    nonCanonical.cards[0]!.scoreTrace!.evidenceResponsibility.summaries.splice(1, 1);
+    expect(() => SafetyScoreV9CurrentResponseSchema.parse(nonCanonical)).toThrow(
+      /must preserve a supported canonical owner order/,
     );
   });
 

--- a/shared/types/safety-score-v9-public.ts
+++ b/shared/types/safety-score-v9-public.ts
@@ -510,10 +510,15 @@ const SafetyScoreV9EvidenceResponsibilityTraceSchema = z
   .strict()
   .superRefine((evidence, ctx) => {
     const actualResponsibilities = evidence.summaries.map((summary) => summary.responsibility);
+    // Two independent compatibility dimensions, deliberately not conflated:
+    // per-fact disclosure paths arrived in 9.19, and the sixth owner
+    // (`published-evidence-expired`) arrived in 9.4. A stored publication can
+    // therefore carry per-fact paths and still predate the sixth owner, so the
+    // legacy order stays readable whatever `facts` says. Newly written
+    // publications are held to the full order by the codec's version gate,
+    // which is where a write-time contract belongs.
     const legacyResponsibilities = RESPONSIBILITIES.slice(0, -1);
-    const supportedResponsibilities = evidence.facts === undefined
-      ? [legacyResponsibilities, RESPONSIBILITIES]
-      : [RESPONSIBILITIES];
+    const supportedResponsibilities = [legacyResponsibilities, RESPONSIBILITIES];
     if (
       !supportedResponsibilities.some(
         (expected) => JSON.stringify(actualResponsibilities) === JSON.stringify(expected),
@@ -522,9 +527,7 @@ const SafetyScoreV9EvidenceResponsibilityTraceSchema = z
       ctx.addIssue({
         code: "custom",
         path: ["summaries"],
-        message: evidence.facts === undefined
-          ? "V9 evidence responsibility summaries without per-fact paths must preserve a supported canonical owner order"
-          : "V9 evidence responsibility summaries must cover every owner in canonical order",
+        message: "V9 evidence responsibility summaries must preserve a supported canonical owner order",
       });
     }
     const expectedTotal = evidence.summaries.reduce((sum, summary) => sum + summary.factCount, 0);

--- a/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
@@ -153,6 +153,61 @@ describe("Safety Score V9 publication codec", () => {
     ).rejects.toThrow(/v9\.19\+ publications require per-fact disclosure paths/);
   });
 
+  it("reads a stored publication that has per-fact paths but predates the sixth owner", async () => {
+    // The exact shape that took production down on the 9.4 release: written by
+    // a post-9.19 Worker, so `facts` is present, but by a pre-9.4 one, so the
+    // sixth responsibility owner is absent. Keying compatibility on `facts`
+    // alone rejected it and the canonical publication became unreadable.
+    const publication = makeWorkerSafetyScoreV9Publication({
+      policyVersion: "9.35",
+    });
+    const envelope = JSON.parse(
+      await serializeSafetyScoreV9Publication(publication),
+    ) as Record<string, unknown>;
+    const storedPublication = JSON.parse(
+      gunzipSync(Buffer.from(String(envelope.payload), "base64")).toString("utf8"),
+    ) as typeof publication;
+    for (const card of storedPublication.cards) {
+      card.scoreTrace.evidenceResponsibility.summaries =
+        card.scoreTrace.evidenceResponsibility.summaries.filter(
+          (summary) => summary.responsibility !== "published-evidence-expired",
+        );
+      card.scoreTrace.evidenceResponsibility.totalFactCount =
+        card.scoreTrace.evidenceResponsibility.summaries.reduce(
+          (sum, summary) => sum + summary.factCount,
+          0,
+        );
+    }
+    expect(storedPublication.cards[0]!.scoreTrace.evidenceResponsibility.facts).toBeDefined();
+    const payload = stableJsonStringifyV1(storedPublication);
+    const compressed = gzipSync(Buffer.from(payload));
+    const stored = stableJsonStringifyV1({
+      ...envelope,
+      payloadSha256: createHash("sha256").update(payload).digest("hex"),
+      uncompressedBytes: Buffer.byteLength(payload),
+      compressedBytes: compressed.byteLength,
+      payload: compressed.toString("base64"),
+    });
+
+    await expect(parseSafetyScoreV9Publication(stored)).resolves.toEqual(
+      storedPublication,
+    );
+  });
+
+  it("rejects post-9.4 serialization that omits an evidence responsibility owner", async () => {
+    const publication = makeWorkerSafetyScoreV9Publication({
+      policyVersion: "9.4",
+    });
+    publication.cards[0]!.scoreTrace.evidenceResponsibility.summaries =
+      publication.cards[0]!.scoreTrace.evidenceResponsibility.summaries.filter(
+        (summary) => summary.responsibility !== "published-evidence-expired",
+      );
+
+    await expect(
+      serializeSafetyScoreV9Publication(publication),
+    ).rejects.toThrow(/v9\.4\+ publications require every evidence responsibility owner/);
+  });
+
   it("rejects a malformed retired stressStateDigest", async () => {
     const publication = makeWorkerSafetyScoreV9Publication();
     const stored = stableJsonStringifyV1({

--- a/worker/src/lib/safety-score-v9-publication-codec.ts
+++ b/worker/src/lib/safety-score-v9-publication-codec.ts
@@ -15,6 +15,7 @@ import { parseJson } from "./json-parse";
 const PUBLICATION_STORAGE_KIND = "safety-score-v9-publication";
 const STORAGE_SCHEMA_VERSION = 1;
 const EVIDENCE_RESPONSIBILITY_FACTS_POLICY_VERSION = "9.19";
+const PUBLISHED_EVIDENCE_EXPIRED_POLICY_VERSION = "9.4";
 
 const SAFETY_SCORE_V9_PUBLICATION_MAX_STORED_BYTES = 1_900_000;
 const SAFETY_SCORE_V9_PUBLICATION_MAX_COMPRESSED_BYTES = 1_350_000;
@@ -216,6 +217,22 @@ export async function serializeSafetyScoreV9Publication(
   ) {
     throw new Error(
       "Safety Score v9.19+ publications require per-fact disclosure paths",
+    );
+  }
+  if (
+    compareMethodologyVersions(
+      publication.policyVersion,
+      PUBLISHED_EVIDENCE_EXPIRED_POLICY_VERSION,
+    ) >= 0 &&
+    publication.cards.some(
+      (card) =>
+        !card.scoreTrace.evidenceResponsibility.summaries.some(
+          (summary) => summary.responsibility === "published-evidence-expired",
+        ),
+    )
+  ) {
+    throw new Error(
+      "Safety Score v9.4+ publications require every evidence responsibility owner",
     );
   }
   const canonical = stableJsonStringifyV1(publication);


### PR DESCRIPTION
**Production hotfix.** `/api/report-cards/v9` has been 503 since the 9.4 release with `V9 evidence responsibility summaries must cover every owner in canonical order`.

The canonical publication stored in D1 was written by the previous deployment, so it carries five responsibility owners. The 9.4 reader refused it, and the cron could not republish because the accepted-first ordering reads that same stored publication — so the outage does not self-heal.

## Cause

The reader collapsed two independent compatibility dimensions into one. Per-fact disclosure paths arrived in 9.19; the sixth owner `published-evidence-expired` arrived in 9.4. The compat window was keyed only on `facts === undefined`, so a publication written between those versions — per-fact paths present, five owners — fell through to the strict branch. That is exactly the shape in production.

## Fix

- The response schema accepts either the legacy five-owner canonical prefix or the full six-owner order, regardless of `facts`. Any other owner set is still refused, so dropping an interior owner remains corruption rather than an older writer.
- Write-time strictness moves to where the existing 9.19 per-fact gate already lives: `serializeSafetyScoreV9Publication` rejects a 9.4+ publication that omits an owner. Freshly written publications stay complete; previously accepted snapshots stay readable.

## Tests

Regression tests pin the exact production shape (per-fact paths present, sixth owner absent) in both the codec and the response schema, plus the new write-side rejection.

No score, grade, digest, or methodology change.