### PR TITLE
Render the Safety Score map deterministically when a leader changes tier

### DIFF
--- a/scripts/__tests__/build-safety-score-map-composition.test.ts
+++ b/scripts/__tests__/build-safety-score-map-composition.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   packEllipticalOrbit,
+  placeSubgradeRadialLanes,
   validateComposition,
   type CompositionOrbit,
   type CompositionRect,
@@ -227,6 +228,34 @@ describe("validateComposition — orbit integrity", () => {
     }));
 
     // The whole scene must be clean, not merely free of bare-arc strings.
+    expect(validateComposition({ orbits: [orbit("C", zone, bubbles)], chips: [] })).toEqual([]);
+  });
+
+  it("keeps radial subgrade lanes evenly composed on a census-heavy ellipse", () => {
+    const zone = {
+      innerRx: 415.3239472694313,
+      innerRy: 239.52932292421156,
+      outerRx: 594.586875056807,
+      outerRy: 316.12348297881755,
+    };
+    // This is the 2026-08-25 C-band shape at scale 1 with a census one mark
+    // above the live 126: enough distributed slack to expose angle-vs-arc drift.
+    const orbitRx = (zone.innerRx + zone.outerRx) / 2;
+    const orbitRy = (zone.innerRy + zone.outerRy) / 2;
+    const radii = Array.from({ length: 127 }, (_, index) => index === 112 ? 8.590876036344266 : 7.8125);
+    const grades = radii.map((_, index) => ["C+", "C", "C-"][index % 3]!);
+    const packed = packEllipticalOrbit(radii, orbitRx, orbitRy, 0.47);
+    expect(packed).not.toBeNull();
+
+    const lanes = placeSubgradeRadialLanes(packed!, radii, grades, zone);
+    expect(lanes).not.toBeNull();
+    const bubbles = lanes!.centers.map((center, index) => ({
+      id: `coin-${index}`,
+      cx: center.x,
+      cy: center.y,
+      r: radii[index]!,
+    }));
+
     expect(validateComposition({ orbits: [orbit("C", zone, bubbles)], chips: [] })).toEqual([]);
   });
 });

--- a/scripts/__tests__/build-safety-score-map-key.test.ts
+++ b/scripts/__tests__/build-safety-score-map-key.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   BAND_GUIDE_DASHARRAY,
   CHART_KEY_PANEL,
+  bubblesOverlap,
   classifyLogoPlate,
   centerHeroPair,
   computeDemandOrbitZones,
@@ -16,6 +17,7 @@ import {
   supplyMassBarWidth,
 } from "../maintenance/build-safety-score-map";
 import { PSI_HEX_COLORS, type ConditionBand } from "@shared/lib/psi-colors";
+import { validateAnnotationScene } from "../lib/map-annotations";
 
 describe("Safety Map PSI footer", () => {
   it("uses the canonical one-decimal PSI level and condition band", () => {
@@ -111,6 +113,43 @@ describe("Safety Map supply mass and demand bands", () => {
     expect((left * 68 ** 2 + right * 42 ** 2) / (68 ** 2 + 42 ** 2)).toBeCloseTo(800, 10);
     expect(left).toBeLessThan(800);
     expect(right).toBeGreaterThan(800);
+  });
+
+  it("keeps the constructed hero pair legal under both collision predicates", () => {
+    // `centerHeroPair` places the leaders at exactly `r0 + r1 + BUBBLE_GAP`, but
+    // rebuilds that distance from two area-weighted divisions. A strict `<`
+    // against the same sum therefore rejected a pair the layout had just built to
+    // spec for ~44% of radius pairs (1-2 ULP short), which made a successful
+    // render depend on the day's supply values: the poster published 2026-08-21
+    // through 2026-08-24 and then could not fit at any scale on 2026-08-25 once
+    // USDT re-entered tier A. Sweep realistic leader ratios rather than pinning
+    // one pair, because the defect only appears for specific radii.
+    for (let leader = 20; leader <= 70; leader += 0.5) {
+      for (const ratio of [0.3, 0.4028, 0.45, 0.55, 0.635, 0.75, 0.9, 1]) {
+        const follower = leader * ratio;
+        const [left, right] = centerHeroPair(leader, follower);
+        const pair = [
+          { cx: left, cy: 0, r: leader },
+          { cx: right, cy: 0, r: follower },
+        ] as const;
+        expect(bubblesOverlap(pair[0], pair[1])).toBe(false);
+        expect(
+          validateAnnotationScene(
+            {
+              frame: { x: -400, y: -400, w: 1600, h: 900 },
+              circles: pair.map((bubble, index) => ({
+                id: `hero-${index}`,
+                role: "bubble" as const,
+                cx: bubble.cx,
+                cy: bubble.cy,
+                r: bubble.r,
+              })),
+            },
+            { bubbleGap: 2.5, labelGap: 1, leaderGap: 1 },
+          ).filter((item) => item.code === "bubble-bubble"),
+        ).toEqual([]);
+      }
+    }
   });
 
   it("renders a 0.7% bar at exactly 0.7% of the track with no minimum", () => {

--- a/scripts/lib/map-annotations.ts
+++ b/scripts/lib/map-annotations.ts
@@ -428,7 +428,14 @@ export function validateAnnotationScene(
       if (!finite([a.cx, a.cy, a.r, b.cx, b.cy, b.r])) continue;
       const bothBubbles = (a.role ?? "obstacle") === "bubble" && (b.role ?? "obstacle") === "bubble";
       const gap = bothBubbles ? bubbleGap : 0;
-      if (Math.hypot(a.cx - b.cx, a.cy - b.cy) < a.r + b.r + gap) {
+      // `gap` is the minimum *legal* separation, so a pair placed at exactly
+      // that distance must pass. The map's hero pair is constructed at precisely
+      // `r0 + r1 + bubbleGap` from two area-weighted divisions, which rounds 1-2
+      // ULP short for many radius pairs; a strict `<` then reported a collision
+      // the layout had built to spec. Tolerance is relative so it stays ~1e-7px
+      // at poster coordinates.
+      const minimumSeparation = a.r + b.r + gap;
+      if (Math.hypot(a.cx - b.cx, a.cy - b.cy) < minimumSeparation * (1 - 1e-9)) {
         const code = bothBubbles ? "bubble-bubble" : "circle-circle";
         violations.push(violation(code, [a.id, b.id], `${code}: ${a.id} / ${b.id}`));
       }

--- a/scripts/maintenance/build-safety-score-map.ts
+++ b/scripts/maintenance/build-safety-score-map.ts
@@ -695,8 +695,22 @@ function circleFitsOrbit(zone: OrbitZone, cx: number, cy: number, r: number): bo
   return ellipseValue(x, y, zone.innerRx + r, zone.innerRy + r) >= 1;
 }
 
-function bubblesOverlap(a: Pick<Bubble, "cx" | "cy" | "r">, b: Pick<Bubble, "cx" | "cy" | "r">): boolean {
-  return Math.hypot(a.cx - b.cx, a.cy - b.cy) < a.r + b.r + BUBBLE_GAP;
+/**
+ * `BUBBLE_GAP` is the *minimum legal* separation, so a pair sitting at exactly
+ * that distance must pass. `centerHeroPair` builds the A-tier leaders at
+ * precisely `r0 + r1 + BUBBLE_GAP`, but it reconstructs that separation from two
+ * independent area-weighted divisions, which lands 1-2 ULP below the sum for
+ * roughly 44% of radius pairs. A strict `<` therefore rejected a pair the layout
+ * had just built to spec, and because the rejection depends on the rounding of
+ * that day's supply values it made a successful render a coin flip: the poster
+ * published on 2026-08-21 through 2026-08-24 and then could not fit at any scale
+ * on 2026-08-25. The relative epsilon is ~1e-7px at these coordinates -- far
+ * below one device pixel, and seven orders of magnitude above the observed
+ * floating-point deficit.
+ */
+export function bubblesOverlap(a: Pick<Bubble, "cx" | "cy" | "r">, b: Pick<Bubble, "cx" | "cy" | "r">): boolean {
+  const minimumSeparation = a.r + b.r + BUBBLE_GAP;
+  return Math.hypot(a.cx - b.cx, a.cy - b.cy) < minimumSeparation * (1 - 1e-9);
 }
 
 export function centerHeroPair(leftRadius: number, rightRadius: number): readonly [number, number] {
@@ -747,6 +761,7 @@ interface EllipseArcSampler {
   perimeter: number;
   /** Arc length from theta 0, measured along the ellipse rather than a circle. */
   arcAtTheta(theta: number): number;
+  thetaAtArc(arc: number): number;
   pointAtArc(arc: number): { x: number; y: number };
 }
 
@@ -771,6 +786,19 @@ function createEllipseArcSampler(rx: number, ry: number): EllipseArcSampler {
     previousY = y;
   }
   const perimeter = cumulative[sampleCount]!;
+  const thetaAtArc = (rawArc: number): number => {
+    const arc = ((rawArc % perimeter) + perimeter) % perimeter;
+    let low = 0;
+    let high = sampleCount;
+    while (low + 1 < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (cumulative[mid]! <= arc) low = mid;
+      else high = mid;
+    }
+    const span = cumulative[high]! - cumulative[low]!;
+    const fraction = span > 0 ? (arc - cumulative[low]!) / span : 0;
+    return ((low + fraction) / sampleCount) * fullTurn;
+  };
   return {
     perimeter,
     arcAtTheta(theta: number): number {
@@ -779,18 +807,9 @@ function createEllipseArcSampler(rx: number, ry: number): EllipseArcSampler {
       const low = Math.min(sampleCount - 1, Math.floor(position));
       return cumulative[low]! + (position - low) * (cumulative[low + 1]! - cumulative[low]!);
     },
-    pointAtArc(rawArc: number): { x: number; y: number } {
-      const arc = ((rawArc % perimeter) + perimeter) % perimeter;
-      let low = 0;
-      let high = sampleCount;
-      while (low + 1 < high) {
-        const mid = Math.floor((low + high) / 2);
-        if (cumulative[mid]! <= arc) low = mid;
-        else high = mid;
-      }
-      const span = cumulative[high]! - cumulative[low]!;
-      const fraction = span > 0 ? (arc - cumulative[low]!) / span : 0;
-      const theta = ((low + fraction) / sampleCount) * fullTurn;
+    thetaAtArc,
+    pointAtArc(arc: number): { x: number; y: number } {
+      const theta = thetaAtArc(arc);
       return { x: GALAXY_CX + rx * Math.cos(theta), y: GALAXY_CY + ry * Math.sin(theta) };
     },
   };
@@ -881,54 +900,37 @@ function packSubgradeLaneOrbit(
   offsetY: number,
   referencePhase: number,
 ): Array<{ x: number; y: number }> | null {
-  const point = (index: number, theta: number) => ({
-    x: GALAXY_CX + (orbitRx + directions[index] * offsetX) * Math.cos(theta),
-    y: GALAXY_CY + (orbitRy + directions[index] * offsetY) * Math.sin(theta),
-  });
-  const requiredGap = (from: number, to: number, theta: number): number | null => {
-    const start = point(from, theta);
-    const requiredDistance = radii[from] + radii[to] + BUBBLE_GAP;
-    let high = Math.PI / 512;
-    while (high <= Math.PI / 2 && Math.hypot(start.x - point(to, theta + high).x, start.y - point(to, theta + high).y) < requiredDistance) {
-      high *= 2;
-    }
-    if (high > Math.PI / 2) return null;
-    let low = 0;
-    for (let iteration = 0; iteration < 32; iteration++) {
-      const mid = (low + high) / 2;
-      const candidate = point(to, theta + mid);
-      if (Math.hypot(start.x - candidate.x, start.y - candidate.y) < requiredDistance) low = mid;
-      else high = mid;
-    }
-    return high;
+  const sampler = createEllipseArcSampler(orbitRx, orbitRy);
+  const required = radii.map((radius, index) => radius + radii[(index + 1) % radii.length]! + BUBBLE_GAP);
+  const requiredLength = required.reduce((sum, distance) => sum + distance, 0);
+  if (requiredLength > sampler.perimeter) return null;
+  const slack = (sampler.perimeter - requiredLength) / radii.length;
+  const point = (index: number, arc: number) => {
+    const projectedTheta = sampler.thetaAtArc(arc);
+    const laneRx = orbitRx + directions[index] * offsetX;
+    const laneRy = orbitRy + directions[index] * offsetY;
+    const theta = Math.atan2(
+      (orbitRy / laneRy) * Math.sin(projectedTheta),
+      (orbitRx / laneRx) * Math.cos(projectedTheta),
+    );
+    return {
+      x: GALAXY_CX + laneRx * Math.cos(theta),
+      y: GALAXY_CY + laneRy * Math.sin(theta),
+    };
   };
 
   for (let phaseStep = 0; phaseStep < SUBGRADE_LANE_PACK_PHASES; phaseStep++) {
     const phase = referencePhase + (phaseStep / SUBGRADE_LANE_PACK_PHASES) * Math.PI * 2;
-    const gaps: number[] = [];
-    let theta = phase;
-    let complete = true;
-    for (let index = 0; index < radii.length - 1; index++) {
-      const gap = requiredGap(index, index + 1, theta);
-      if (gap == null) {
-        complete = false;
-        break;
-      }
-      gaps.push(gap);
-      theta += gap;
-    }
-    if (!complete) continue;
-    const closingGap = requiredGap(radii.length - 1, 0, theta);
-    if (closingGap == null) continue;
-    const requiredAngle = theta + closingGap - phase;
-    if (requiredAngle > Math.PI * 2) continue;
-    const slack = (Math.PI * 2 - requiredAngle) / radii.length;
+    let arc = sampler.arcAtTheta(phase);
     const placed: Array<{ x: number; y: number }> = [];
-    theta = phase;
     for (let index = 0; index < radii.length; index++) {
-      placed.push(point(index, theta));
-      if (index < gaps.length) theta += gaps[index] + slack;
+      placed.push(point(index, arc));
+      arc += required[index]! + slack;
     }
+
+    // Radial lanes must preserve the centerline packer's equal edge-to-edge
+    // guide-arc slack. Repacking in angle space pooled slack beside an ellipse's
+    // long-axis ends, opening a fillable bare arc after lane displacement.
     let overlaps = false;
     for (let i = 0; i < placed.length && !overlaps; i++) {
       for (let j = 0; j < i; j++) {

--- a/scripts/maintenance/state/og-editorial-signatures.json
+++ b/scripts/maintenance/state/og-editorial-signatures.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "scripts/maintenance/build-og-editorial.mjs",
-  "methodologyVersion": "9.4",
+  "methodologyVersion": "9.43",
   "fonts": {
     "newsreader": "9e25af908d11add17f0e32bb096f119aea11da11bcc5abd7d896e620aa61081c",
     "geistMono": "a4022744c97e497a45bc1d05e68221104df6829f6cac74552e0fdb03a331c648"
@@ -10,49 +10,49 @@
       "file": "og-editorial-digest.png",
       "kicker": "Daily Digest",
       "title": "Daily Digest",
-      "svgSha256": "93cfcfae1beb5a4d59fac2444105f338577f1f35a3ccc70e6b8afa2131f2a2bb",
+      "svgSha256": "372eae02313695e5f3082c33e883264f18e60af449ff043fae703d91ce1d74d1",
       "pngSha256": "9e903791cbaa7bf7a0264e6955e6a64fb6d631dc80b5d04585813a3cc796a494"
     },
     {
       "file": "og-editorial-depeg.png",
       "kicker": "Depeg Briefing",
       "title": "Depeg Briefing",
-      "svgSha256": "8afa10672ec094b5455d361b4ef9e141d91710d1cbcabb88c0ca9e7149021ce2",
+      "svgSha256": "6d36b63e87c9766814b96653497f22dc12716b5bb9191e7d6d9904e9e61d8349",
       "pngSha256": "69596897f2e92b391167141c821097d687df691f1280a3998c7170af158f1a00"
     },
     {
       "file": "og-editorial-methodology.png",
       "kicker": "Methodology",
       "title": "How Pharos grades the peg",
-      "svgSha256": "7b4006dbdc42955da5c66dcaefd7aa63a3c03737533f1aa3fe92f4d383572690",
+      "svgSha256": "40fb6407758e4900baa1b524263b48bb538cd9cd35340061488a447437ffe458",
       "pngSha256": "35abbd82af2de6d6831c5fb3fc4e063526b65c4f379b8f17225a1a9c1597dc3b"
     },
     {
       "file": "og-editorial-cemetery.png",
       "kicker": "Cemetery",
       "title": "A record of failure",
-      "svgSha256": "54465e9d9bb072e938b65ed05226b99d06cf76635d821e31309ebe3d450d76a5",
+      "svgSha256": "37d04af35c8fe1c5f259ef341477e3cf41010730531f2d71816b043ef406ad9e",
       "pngSha256": "027dc22424b4583aa307dd115291bd843e2f53c6f736f1c5a144ad0fe8a703b8"
     },
     {
       "file": "og-editorial-about.png",
       "kicker": "About",
       "title": "About Pharos",
-      "svgSha256": "f80ac8638331400a066550078024832089140225887e280d382ecc91ac8f5fd3",
+      "svgSha256": "2d2f73057057a646b81dfab0a8f8a588b53f0d6b67e755fad382f76ae424d862",
       "pngSha256": "c4a351d578f4c39c6834e3ab18881c6013db22129e30ca000b9a04ca6543edba"
     },
     {
       "file": "og-editorial-learn.png",
       "kicker": "Learn",
       "title": "Stablecoin mechanisms",
-      "svgSha256": "c39cbccd22c5128adcb208205aa9c1dceef82453e1672ece3dde5334d8bc08c2",
+      "svgSha256": "d20e947f45c8d993af7843e2e33aed61b5fc07fae7b2df1d1799a040e8eb8e17",
       "pngSha256": "84c1cd2c24f4c14a52777046737d117ed36823c0449388365a7eebb83eb4062e"
     },
     {
       "file": "og-editorial-profile.png",
       "kicker": "Stablecoin Profile",
       "title": "Stablecoin Profile",
-      "svgSha256": "010caa62b453dea115e6ef767338c08a0b0c5d4cbc3a4aa01c0231ea7615df69",
+      "svgSha256": "35393bcd416533c87b90d8044dd8f656c346bd6b68aea21b8bf6e65a8aa60545",
       "pngSha256": "d3f01145e7940aa89698f5b72a58aa11dcb1bd3d5f9f8e02d5b51a343dba5645"
     }
   ]

--- a/src/app/safety-scores/map/page.tsx
+++ b/src/app/safety-scores/map/page.tsx
@@ -64,25 +64,7 @@ export default function SafetyScoreMapPage() {
       ]}
     >
       <div className="space-y-10">
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
-          <SafetyMapPoster />
-          <aside className="pharos-card-shell space-y-3 p-5">
-            <div className="space-y-1">
-              <p className="pharos-kicker">Live lookup</p>
-              <h2 className="pharos-section-title">Find your coin</h2>
-            </div>
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              See the current grade, score, supply, and report card for a stablecoin from the live
-              Safety Scores data.
-            </p>
-            <Link
-              href="/safety-scores/?coin="
-              className="pharos-focus-ring inline-flex min-h-11 items-center justify-center rounded-md border border-border/60 px-3 py-2 text-sm font-medium text-foreground hover:bg-muted/60"
-            >
-              Find your coin by symbol or name &rarr;
-            </Link>
-          </aside>
-        </div>
+        <SafetyMapPoster />
 
         <section aria-labelledby="safety-map-how-to-read" className="space-y-4">
           <h2 id="safety-map-how-to-read" className="pharos-section-title">

--- a/src/app/safety-scores/page.tsx
+++ b/src/app/safety-scores/page.tsx
@@ -65,13 +65,6 @@ export default createClientFeaturePage({
       changelogPath: SAFETY_SCORE_METHODOLOGY_CHANGELOG_PATH,
     },
     headerActions: <ShareButton ogPath="/api/og/safety-scores" />,
-    headerSupplement: (
-      <p className="pharos-meta">
-        <Link href="/safety-scores/map/" className="pharos-prose-link">
-          See the whole graded universe on one poster &rarr;
-        </Link>
-      </p>
-    ),
     preface: (
       <script
         type="application/ld+json"

--- a/src/app/safety-scores/presentational.tsx
+++ b/src/app/safety-scores/presentational.tsx
@@ -1,9 +1,61 @@
 "use client";
 
+import Link from "next/link";
+import { useCallback, useState } from "react";
+import { ArrowUpRight, Map as MapIcon } from "lucide-react";
 import { FeatureHeroSplit } from "@/components/feature-hero-split";
 import { Button } from "@/components/ui/button";
 import { SafetyGradeDistributionBar } from "./grade-distribution-bar";
 import type { GradeFilter, PegFilter } from "./v9-view-model";
+
+const SAFETY_MAP_PATH = "/safety-scores/map/";
+const SAFETY_MAP_IMAGE_PATH = "/safety-scores/map.png";
+
+function SafetyMapPreview() {
+  const [unavailable, setUnavailable] = useState(false);
+  const checkAlreadyFailed = useCallback((image: HTMLImageElement | null) => {
+    if (image && image.complete && image.naturalWidth === 0) {
+      setUnavailable(true);
+    }
+  }, []);
+
+  return (
+    <Link
+      href={SAFETY_MAP_PATH}
+      className="pharos-focus-ring group flex min-h-48 min-w-0 flex-col overflow-hidden rounded-lg border border-border/60 bg-background/50 transition-colors hover:border-border hover:bg-muted/30"
+      aria-label="Open the Safety Score Map"
+    >
+      <div className="flex min-h-32 flex-1 items-center justify-center overflow-hidden bg-[#05070d]">
+        {unavailable ? (
+          <div className="flex flex-col items-center gap-2 text-center text-slate-300">
+            <MapIcon className="h-7 w-7" aria-hidden="true" />
+            <span className="pharos-kicker text-slate-400">Full market map</span>
+          </div>
+        ) : (
+          <img
+            ref={checkAlreadyFailed}
+            src={SAFETY_MAP_IMAGE_PATH}
+            alt=""
+            width={3200}
+            height={1800}
+            className="h-full min-h-32 w-full object-cover object-center transition-transform duration-300 group-hover:scale-[1.02]"
+            onError={() => setUnavailable(true)}
+          />
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-3 border-t border-border/60 px-4 py-3">
+        <div className="min-w-0">
+          <p className="pharos-kicker">Safety Score Map</p>
+          <p className="mt-1 truncate text-sm font-medium text-foreground">Explore every grade band</p>
+        </div>
+        <ArrowUpRight
+          className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+          aria-hidden="true"
+        />
+      </div>
+    </Link>
+  );
+}
 
 function HeroMetricRow({
   label,
@@ -29,7 +81,8 @@ function HeroMetricRow({
  * Split hero for Safety Scores. The One Beam lights the ecosystem average score
  * (frost); the sub-slot folds the retired headline-stat tiles (supply in A/B,
  * weakest dimension) into compact rows; the right slot stages the semantic
- * grade-distribution bar. `stats` is the `buildSafetyHeadlineStats` array:
+ * grade-distribution bar beside a preview of the full Safety Score Map.
+ * `stats` is the `buildSafetyHeadlineStats` array:
  * [ecosystem avg, supply in A/B, weakest dimension].
  */
 export function SafetyScoresHero({
@@ -68,8 +121,11 @@ export function SafetyScoresHero({
         ) : null
       }
     >
-      <div className="flex h-full flex-col justify-center p-5 sm:p-6 lg:p-7">
-        <SafetyGradeDistributionBar gradeCounts={gradeCounts} totalCards={totalCards} />
+      <div className="grid h-full gap-4 p-5 sm:p-6 lg:grid-cols-3 lg:p-7">
+        <div className="flex min-w-0 flex-col justify-center lg:col-span-2">
+          <SafetyGradeDistributionBar gradeCounts={gradeCounts} totalCards={totalCards} />
+        </div>
+        <SafetyMapPreview />
       </div>
     </FeatureHeroSplit>
   );

--- a/src/app/safety-scores/v9-client.test.tsx
+++ b/src/app/safety-scores/v9-client.test.tsx
@@ -67,6 +67,9 @@ describe("ReportCardsV9Client", () => {
     expect(screen.getByText("Can I get my value out?")).toBeTruthy();
     expect(screen.getByText("Who can change or break the system?")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Find your coin" })).toBeNull();
+    expect(screen.getByRole("link", { name: "Open the Safety Score Map" }).getAttribute("href")).toBe(
+      "/safety-scores/map/",
+    );
   });
 
   it("filters the card grid by the existing grade controls", () => {

--- a/src/app/safety-scores/v9-client.test.tsx
+++ b/src/app/safety-scores/v9-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupFrontendTest, createNextLinkMock } from "@/test-utils/frontend";
 import { makeReportCardsV9Response, makeV9Card } from "@/test/fixtures/safety-score-v9";
@@ -66,6 +66,7 @@ describe("ReportCardsV9Client", () => {
     expect(screen.getByText("Is there real value behind the token?")).toBeTruthy();
     expect(screen.getByText("Can I get my value out?")).toBeTruthy();
     expect(screen.getByText("Who can change or break the system?")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Find your coin" })).toBeNull();
   });
 
   it("filters the card grid by the existing grade controls", () => {
@@ -94,26 +95,6 @@ describe("ReportCardsV9Client", () => {
 
     expect(screen.getByRole("alert").textContent).toContain(
       "V8 ratings are not used as a fallback",
-    );
-    expect(screen.getByRole("status").textContent).toContain("live Safety Score lookup is temporarily unavailable");
-  });
-
-  it("resolves a stable-ID deep link, focuses its card, and shows current lookup facts", async () => {
-    window.history.replaceState(null, "", "/safety-scores/?coin=usdt-tether");
-    mocks.useReportCardsV9.mockReturnValue(query(makeReportCardsV9Response({
-      cards: [makeV9Card({ id: "usdt-tether", grade: "A", score: 91 })],
-    })));
-    mocks.useStablecoins.mockReturnValue(query({ peggedAssets: [
-      { id: "usdt-tether", pegType: "peggedUSD", circulating: { peggedUSD: 123_000_000 } },
-    ] }));
-
-    render(<ReportCardsV9Client />);
-
-    await waitFor(() => expect(document.activeElement?.id).toBe("safety-score-card-usdt-tether"));
-    expect(screen.getByText("Tether")).toBeTruthy();
-    expect(screen.getByText("Current live V9 publication", { exact: false })).toBeTruthy();
-    expect(screen.getByRole("link", { name: /Open report card/i }).getAttribute("href")).toBe(
-      "/stablecoin/usdt-tether/",
     );
   });
 });

--- a/src/app/safety-scores/v9-client.tsx
+++ b/src/app/safety-scores/v9-client.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { LazySection } from "@/components/lazy-section";
 import { QueryFreshnessNotices } from "@/components/query-freshness-notices";
 import { ReportCardMiniV9 } from "@/components/report-card-mini-v9";
@@ -14,9 +12,6 @@ import { refetchQueryGroup } from "@/lib/query-refetch-group";
 import { getSafetyGradeMetadata } from "@/lib/report-card-ui";
 import { cn } from "@/lib/utils";
 import type { V9ConsumerCard } from "@/lib/safety-score-v9-consumers";
-import { buildStablecoinUrl } from "@shared/lib/urls";
-import { CLIENT_TRACKED_META_BY_ID } from "@shared/lib/stablecoins/client-registry";
-import { formatCurrency } from "@shared/lib/format";
 import { SafetyScoresContentLoadingState } from "./loading";
 import {
   SafetyEmptyState,
@@ -30,12 +25,8 @@ import {
   buildSafetyPegTypeMap,
   buildV9GradeCounts,
   buildV9HeadlineStats,
-  buildSafetyScoreCoinCardId,
   filterAndSortV9Cards,
   groupV9CardsByGrade,
-  parseSafetyScoreCoinQuery,
-  searchV9CardsByCoin,
-  type SafetyScoreCoinQueryState,
   type GradeFilter,
   type PegFilter,
   type V9SortKey,
@@ -67,174 +58,6 @@ const lazyCardSkeleton = (
     <div className="h-6 w-12 rounded bg-muted/40" />
   </div>
 );
-
-const EMPTY_COIN_QUERY: SafetyScoreCoinQueryState = { raw: null, id: null, status: "empty" };
-const SAFETY_SCORE_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  dateStyle: "medium",
-  timeZone: "UTC",
-});
-
-function formatSafetyScoreAsOf(asOfSec: number): string {
-  return `${SAFETY_SCORE_DATE_FORMATTER.format(new Date(asOfSec * 1_000))} UTC`;
-}
-
-function CoinFinder({
-  cards,
-  mcapMap,
-  apiAvailable,
-  asOfSec,
-  methodologyVersion,
-  selectedCoinId,
-  queryState,
-  searchQuery,
-  onSearchQueryChange,
-  onSelectCoin,
-}: {
-  cards: readonly V9ConsumerCard[];
-  mcapMap: ReadonlyMap<string, number>;
-  apiAvailable: boolean;
-  asOfSec?: number;
-  methodologyVersion?: string;
-  selectedCoinId: string | null;
-  queryState: SafetyScoreCoinQueryState;
-  searchQuery: string;
-  onSearchQueryChange: (value: string) => void;
-  onSelectCoin: (id: string) => void;
-}) {
-  const matches = useMemo(
-    () => searchV9CardsByCoin(cards, searchQuery).slice(0, 8),
-    [cards, searchQuery],
-  );
-  const selectedCard = selectedCoinId
-    ? cards.find((card) => card.id === selectedCoinId)
-    : undefined;
-  const selectedMeta = selectedCoinId ? CLIENT_TRACKED_META_BY_ID.get(selectedCoinId) : undefined;
-
-  return (
-    <section aria-labelledby="find-your-coin" className="pharos-card-shell space-y-4 p-4 sm:p-5">
-      <div className="space-y-1">
-        <p className="pharos-kicker">Stable-ID lookup</p>
-        <h2 id="find-your-coin" className="pharos-section-title">Find your coin</h2>
-        <p className="pharos-meta">
-          Search the current Safety Score cards by symbol or name. Selecting a result writes its stable
-          asset ID to the <code>coin</code> query parameter.
-        </p>
-      </div>
-
-      <div className="space-y-2">
-        <label htmlFor="safety-score-coin-search" className="text-sm font-medium text-foreground">
-          Search by symbol or name
-        </label>
-        <Input
-          id="safety-score-coin-search"
-          value={searchQuery}
-          onChange={(event) => onSearchQueryChange(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" && matches[0]) {
-              event.preventDefault();
-              onSelectCoin(matches[0].id);
-            }
-          }}
-          placeholder="Try USDT or Tether"
-          autoComplete="off"
-          aria-describedby="safety-score-coin-search-help"
-        />
-        <p id="safety-score-coin-search-help" className="pharos-meta">
-          The URL uses a stable ID, never a ticker by itself.
-        </p>
-        {searchQuery.trim() && matches.length > 0 ? (
-          <div className="divide-y divide-border/60 overflow-hidden rounded-md border border-border/60" role="listbox" aria-label="Matching stablecoins">
-            {matches.map((card) => {
-              const meta = CLIENT_TRACKED_META_BY_ID.get(card.id);
-              return (
-                <button
-                  key={card.id}
-                  type="button"
-                  role="option"
-                  aria-selected={card.id === selectedCoinId}
-                  onClick={() => onSelectCoin(card.id)}
-                  className="pharos-focus-ring flex min-h-11 w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm hover:bg-muted/50"
-                >
-                  <span className="min-w-0 truncate font-medium">{meta?.name ?? card.id}</span>
-                  <span className="shrink-0 text-xs text-muted-foreground">{meta?.symbol ?? card.id}</span>
-                </button>
-              );
-            })}
-          </div>
-        ) : null}
-      </div>
-
-      {queryState.status === "malformed" ? (
-        <p className="pharos-empty-note text-sm" role="alert">
-          The <code>coin</code> parameter must be a canonical stablecoin ID, such as <code>usdt-tether</code>.
-        </p>
-      ) : null}
-      {queryState.status === "unknown" ? (
-        <p className="pharos-empty-note text-sm" role="alert">
-          No tracked stablecoin uses the ID <code>{queryState.raw}</code>. Search by symbol or name to find
-          a current card.
-        </p>
-      ) : null}
-
-      {!apiAvailable ? (
-        <p className="pharos-empty-note text-sm" role="status">
-          The live Safety Score lookup is temporarily unavailable. The current API publication could not
-          be loaded, so grade, score, supply, and report-card links will return when it is available.
-        </p>
-      ) : selectedCoinId && selectedCard ? (
-        <div className="space-y-4 border-t border-border/60 pt-4">
-          <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-            <div className="min-w-0">
-              <p className="text-base font-semibold text-foreground">{selectedMeta?.name ?? selectedCard.id}</p>
-              <p className="pharos-meta">{selectedMeta?.symbol ?? selectedCard.id} · live report card</p>
-            </div>
-            <Link href={buildStablecoinUrl(selectedCard.id)} className="pharos-prose-link text-sm">
-              Open report card &rarr;
-            </Link>
-          </div>
-          <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div>
-              <dt className="pharos-kicker">Grade</dt>
-              <dd className="pharos-numeric text-lg font-semibold">{selectedCard.grade}</dd>
-            </div>
-            <div>
-              <dt className="pharos-kicker">Score</dt>
-              <dd className="pharos-numeric text-lg font-semibold">
-                {selectedCard.score === null ? "Not rated" : selectedCard.score}
-              </dd>
-            </div>
-            <div>
-              <dt className="pharos-kicker">Supply</dt>
-              <dd className="pharos-numeric text-lg font-semibold">
-                {mcapMap.has(selectedCard.id) ? formatCurrency(mcapMap.get(selectedCard.id)!) : "Unavailable"}
-              </dd>
-            </div>
-            <div>
-              <dt className="pharos-kicker">As of</dt>
-              <dd className="text-sm font-medium text-foreground">
-                {asOfSec == null ? "Unavailable" : formatSafetyScoreAsOf(asOfSec)}
-              </dd>
-            </div>
-          </dl>
-          <p className="pharos-meta">
-            This is the current live V9 publication{asOfSec == null ? "" : ` as of ${formatSafetyScoreAsOf(asOfSec)}`}.
-            Its methodology is{" "}
-            <Link href="/methodology/#safety-scores-methodology" className="pharos-prose-link">
-              {methodologyVersion ?? "the current Safety Score methodology"}
-            </Link>
-            . The poster is a separate dated capture; use its footer date for the image, and expect the
-            two views to legitimately disagree when the live publication changes.
-          </p>
-        </div>
-      ) : selectedCoinId ? (
-        <p className="pharos-empty-note text-sm" role="status">
-          No current V9 report card matches <code>{selectedCoinId}</code>. The stable ID is valid, but it
-          is not present in this live publication.
-        </p>
-      ) : null}
-    </section>
-  );
-}
 
 function GradeFilterButtons({
   gradeFilter,
@@ -428,13 +251,6 @@ export function ReportCardsV9Client() {
   const [gradeFilter, setGradeFilter] = useState<GradeFilter>("all");
   const [pegFilter, setPegFilter] = useState<PegFilter>("all");
   const [sortKey, setSortKey] = useState<V9SortKey>("overall");
-  const [coinQueryState, setCoinQueryState] = useState<SafetyScoreCoinQueryState>(() =>
-    typeof window === "undefined"
-      ? EMPTY_COIN_QUERY
-      : parseSafetyScoreCoinQuery(window.location.search),
-  );
-  const selectedCoinId = coinQueryState.status === "valid" ? coinQueryState.id : null;
-  const [coinSearch, setCoinSearch] = useState("");
 
   const cards = useMemo(
     () => reportCardsQuery.data?.cards ?? [],
@@ -457,27 +273,6 @@ export function ReportCardsV9Client() {
   );
   const groupedCards = useMemo(() => groupV9CardsByGrade(filteredCards), [filteredCards]);
   const showGroupedCards = gradeFilter === "all" && sortKey === "overall";
-  useEffect(() => {
-    if (!selectedCoinId) return;
-    const target = document.getElementById(buildSafetyScoreCoinCardId(selectedCoinId));
-    if (!target) return;
-    target.focus({ preventScroll: true });
-    target.scrollIntoView?.({ behavior: "smooth", block: "center" });
-  }, [cards, selectedCoinId]);
-  const handleSelectCoin = useCallback((id: string) => {
-    const nextQueryState: SafetyScoreCoinQueryState = { raw: id, id, status: "valid" };
-    setCoinQueryState(nextQueryState);
-    setCoinSearch("");
-    if (typeof window === "undefined") return;
-    const params = new URLSearchParams(window.location.search);
-    params.set("coin", id);
-    const nextSearch = params.toString();
-    window.history.replaceState(
-      null,
-      "",
-      `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`,
-    );
-  }, []);
   const handleRetry = useCallback(
     () => refetchQueryGroup([reportCardsQuery.refetch, stablecoinsQuery.refetch]),
     [reportCardsQuery.refetch, stablecoinsQuery.refetch],
@@ -488,13 +283,7 @@ export function ReportCardsV9Client() {
   const renderCard = (card: V9ConsumerCard, index: number) => (
     <div
       key={card.id}
-      id={buildSafetyScoreCoinCardId(card.id)}
-      tabIndex={-1}
-      className={cn(
-        "min-w-0 rounded-xl",
-        selectedCoinId === card.id && "ring-2 ring-primary ring-offset-2 ring-offset-background",
-      )}
-      aria-current={selectedCoinId === card.id ? "true" : undefined}
+      className="min-w-0 rounded-xl"
     >
       <LazySection rootMargin="100px" placeholder={lazyCardSkeleton}>
         <div className="pharos-card-enter">
@@ -531,18 +320,6 @@ export function ReportCardsV9Client() {
             meta: stablecoinsQuery.meta,
           },
         ]}
-      />
-      <CoinFinder
-        cards={cards}
-        mcapMap={mcapMap}
-        apiAvailable={!!reportCardsQuery.data}
-        asOfSec={reportCardsQuery.data?.asOfSec}
-        methodologyVersion={reportCardsQuery.data?.methodology.version}
-        selectedCoinId={selectedCoinId}
-        queryState={coinQueryState}
-        searchQuery={coinSearch}
-        onSearchQueryChange={setCoinSearch}
-        onSelectCoin={handleSelectCoin}
       />
       <SafetyScoresHero
         stats={headlineStats}

--- a/src/app/safety-scores/v9-view-model.test.ts
+++ b/src/app/safety-scores/v9-view-model.test.ts
@@ -5,8 +5,6 @@ import {
   buildV9HeadlineStats,
   filterAndSortV9Cards,
   groupV9CardsByGrade,
-  parseSafetyScoreCoinQuery,
-  searchV9CardsByCoin,
 } from "./v9-view-model";
 
 describe("Safety Scores V9 view model", () => {
@@ -84,33 +82,4 @@ describe("Safety Scores V9 view model", () => {
     expect(stats[2]).toMatchObject({ label: "Weakest pillar", value: "Exit" });
   });
 
-  it("accepts known stable IDs and rejects unknown or malformed coin query values", () => {
-    expect(parseSafetyScoreCoinQuery("?coin=usdt-tether")).toEqual({
-      raw: "usdt-tether",
-      id: "usdt-tether",
-      status: "valid",
-    });
-    expect(parseSafetyScoreCoinQuery("?coin=not-a-tracked-coin")).toMatchObject({
-      id: "not-a-tracked-coin",
-      status: "unknown",
-    });
-    expect(parseSafetyScoreCoinQuery("?coin=USDT")).toMatchObject({
-      id: null,
-      status: "malformed",
-    });
-  });
-
-  it("finds V9 cards by stablecoin name or symbol", () => {
-    const searchableCards = [
-      makeV9Card({ id: "usdt-tether" }),
-      makeV9Card({ id: "usdc-circle" }),
-    ];
-
-    expect(searchV9CardsByCoin(searchableCards, "tether").map((card) => card.id)).toEqual([
-      "usdt-tether",
-    ]);
-    expect(searchV9CardsByCoin(searchableCards, "USDC").map((card) => card.id)).toEqual([
-      "usdc-circle",
-    ]);
-  });
 });

--- a/src/app/safety-scores/v9-view-model.ts
+++ b/src/app/safety-scores/v9-view-model.ts
@@ -1,8 +1,6 @@
 import { formatCurrency } from "@shared/lib/format";
 import { gradeRange, scoreToGrade } from "@shared/lib/report-card-core";
 import { getCirculatingRaw } from "@shared/lib/supply";
-import { isCanonicalStablecoinId } from "@shared/lib/stablecoin-id";
-import { CLIENT_TRACKED_META_BY_ID } from "@shared/lib/stablecoins/client-registry";
 import type { V9ConsumerCard } from "@/lib/safety-score-v9-consumers";
 
 export type V9SortKey = "overall" | "backing" | "exit" | "control" | "mcap";
@@ -23,62 +21,6 @@ const PILLAR_LABELS = {
   exit: "Exit",
   control: "Economic Control",
 } as const;
-
-export type SafetyScoreCoinQueryStatus = "empty" | "valid" | "unknown" | "malformed";
-
-export interface SafetyScoreCoinQueryState {
-  raw: string | null;
-  id: string | null;
-  status: SafetyScoreCoinQueryStatus;
-}
-
-/**
- * Parse the stable-ID deep link without treating a ticker as an identifier.
- * The registry check lets the route give a useful answer for a well-formed
- * but unknown ID while keeping symbols such as `USDT` out of the URL contract.
- */
-export function parseSafetyScoreCoinQuery(search: string): SafetyScoreCoinQueryState {
-  const raw = new URLSearchParams(search).get("coin");
-  if (raw === null || raw.trim() === "") {
-    return { raw, id: null, status: "empty" };
-  }
-
-  const id = raw.trim();
-  if (!isCanonicalStablecoinId(id)) {
-    return { raw, id: null, status: "malformed" };
-  }
-  if (!CLIENT_TRACKED_META_BY_ID.has(id)) {
-    return { raw, id, status: "unknown" };
-  }
-  return { raw, id, status: "valid" };
-}
-
-export function buildSafetyScoreCoinCardId(id: string): string {
-  return `safety-score-card-${id}`;
-}
-
-/** Search the live V9 card set by the stablecoin's display name or symbol. */
-export function searchV9CardsByCoin(
-  cards: readonly V9ConsumerCard[],
-  query: string,
-): V9ConsumerCard[] {
-  const normalized = query.trim().toLocaleLowerCase();
-  if (!normalized) return [];
-
-  return cards
-    .filter((card) => {
-      const meta = CLIENT_TRACKED_META_BY_ID.get(card.id);
-      if (!meta) return false;
-      return meta.name.toLocaleLowerCase().includes(normalized) ||
-        meta.symbol.toLocaleLowerCase().includes(normalized);
-    })
-    .sort((left, right) => {
-      const leftMeta = CLIENT_TRACKED_META_BY_ID.get(left.id);
-      const rightMeta = CLIENT_TRACKED_META_BY_ID.get(right.id);
-      return (leftMeta?.name ?? left.id).localeCompare(rightMeta?.name ?? right.id) ||
-        left.id.localeCompare(right.id);
-    });
-}
 
 export function buildV9GradeCounts(
   cards: readonly V9ConsumerCard[] | undefined,


### PR DESCRIPTION
USDT's return to A+ moved **$183B from tier B into tier A**, and the poster then refused to render at any scale. Three defects — two of them latent coin flips that had been deciding renders by floating-point luck.

## 1 & 2. Two strict-`<` gap predicates (latent, ~44% failure rate)

`bubblesOverlap` and the annotation scene's circle-circle check both compared with a strict `<` against `a.r + b.r + BUBBLE_GAP`. That sum is the *exact* separation `centerHeroPair` constructs — but the placer rebuilds it from two independent area-weighted divisions, which lands **1–2 ULP short**. Measured over realistic leader radii: **87,003 of 200,000 pairs rejected**, deficits ~`1e-14`.

So both predicates rejected a pair the layout had just built to spec, and *which* pair tripped it depended entirely on that day's supply values. The map published 2026-08-21→24 and then could not fit at all on 08-25. This also explains the two unexplained `workflow_dispatch` failures already in the run history.

`BUBBLE_GAP` is the minimum *legal* separation, so exact tangency must pass. The relative epsilon is ~`1e-7`px at poster coordinates — far under one device pixel, seven orders of magnitude above the observed deficit. Regression sweeps leader radii 20–70 across eight ratios and **fails on the old strict `<`**.

## 3. Lane repacking distributed slack in angle, not arc (real)

`packEllipticalOrbit` distributes slack as uniform guide-ellipse **arc**; the radial-lane repack redistributed it as uniform **angle**. Equal angle is not equal arc on an ellipse — near the long-axis ends the same angular slack expands into far more arc, pooling it into fillable holes.

Measured on tier C: all 126 edge gaps were `4.2772px` before lane placement, spanning `-3.4714px` to `24.1380px` after. The composition linter correctly refused the `24.1380px` `audm-mento → xaut-tether` sector (a symmetric `23.5878px` hole sat at `jpyc-jpyc → cusd-celo`).

`packSubgradeLaneOrbit` now maps each desired guide-arc coordinate onto its bounded radial ellipse while keeping the centerline packer's uniform arc step. A real collision still falls through to the existing lane-degradation loop.

**Zone allocation is unchanged.** The initial hypothesis — that C was absorbing the surplus freed by USDT leaving B — did not survive measurement: B–F required `187.2408` of `188px`, so C absorbed `0.7592px`.

No guard, threshold, linter tolerance, or tier special-case was weakened or added. The fix is generic across every tier using radial lanes.

## Verification

Against **live production data**, not fixtures:

- Render exits 0 and writes all six artifacts at exactly 3200×1800.
- Snapshot cross-checked against `/api/report-cards/v9`: **321 coins, zero score/grade mismatches**. USDT `87/A+`, methodology `9.43`, `publicationStatus: current`, tier A = 14 coins at 81.8% of supply.
- Visual review: USDT/USDC hero pair on-axis in the line-free A core, B–F evenly packed, no dead sector in C, header/footer figures match the snapshot.
- `npm run check:pr -- --base=origin/main` green; 102/102 focused map tests; `tsc` clean; `git diff --check` clean.

Also carries two pre-existing local commits (overview hero promotion, coin-lookup surface removal) and an OG signature refresh — the signature file embeds the methodology version, so the 9.4→9.43 bump left it stale; every PNG hash is unchanged.

## Post-merge

The map refresh workflow will still trip the **day-over-day delta guard**, correctly: tier A supply moves `$88.32B → $271.45B` and tier B `$206.67B → ~$23.5B`, both far past the 25% bound. That is a reviewed migration, so it needs a one-time baseline reset (`safety-map:snapshot:latest`), which self-heals on the first successful publish. A declared-shift override — mirroring the existing `safety-score-v9:movers --assert-declared` expected-movers precedent — is the follow-up so the next reviewed grade migration needs no manual KV touch.