### PR TITLE
fix(release): JSON public-doc manifest and compile-inputs before data refresh

### DIFF
--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -50,6 +50,10 @@ jobs:
           bootstrap-generated: "false"
           next-cache: "true"
           next-cache-save: "true"
+      - name: Materialize compile-input artifacts
+        # The dataset refresh consumes the generated stablecoin catalog, so
+        # compile inputs must exist before the refresh runs.
+        run: npm run prebuild -- --build-lifecycle=compile-input
       - name: Refresh API-backed release data
         if: ${{ inputs.refresh_data }}
         env:
@@ -67,7 +71,7 @@ jobs:
           API_BASE_URL: ""
           PHAROS_RELEASE_PR_TYPECHECKED: "1"
         run: |
-          npm run prebuild -- --build-lifecycle=compile-input,post-refresh
+          npm run prebuild -- --build-lifecycle=post-refresh
           npx --no-install next build --webpack
           npm run postbuild
       - name: Validate static SEO and published archive continuity

--- a/scripts/__tests__/ci-workflow-scope.test.ts
+++ b/scripts/__tests__/ci-workflow-scope.test.ts
@@ -28,7 +28,12 @@ describe("CI workflow scope", () => {
     expect(workflow).toContain('next-cache-save: "true"');
     expect(workflow).toContain('PHAROS_RELEASE_PR_TYPECHECKED: "1"');
     expect(workflow).toContain("npm run check:pages-release");
-    expect(workflow).toContain("npm run prebuild -- --build-lifecycle=compile-input,post-refresh");
+    const compileInputAt = workflow.indexOf("npm run prebuild -- --build-lifecycle=compile-input");
+    const refreshAt = workflow.indexOf("refresh-pages-release-data.ts");
+    const postRefreshAt = workflow.indexOf("npm run prebuild -- --build-lifecycle=post-refresh");
+    expect(compileInputAt).toBeGreaterThan(-1);
+    expect(refreshAt).toBeGreaterThan(compileInputAt);
+    expect(postRefreshAt).toBeGreaterThan(refreshAt);
     expect(workflow).not.toContain("rm -rf .next");
   });
 

--- a/scripts/lib/automation-registry.mjs
+++ b/scripts/lib/automation-registry.mjs
@@ -1,5 +1,7 @@
 import { SITEMAP_COMMIT_DERIVED_SOURCE_PATHS } from "./sitemap-source-paths.mts";
-import { PUBLIC_DOC_SOURCE_FILES } from "../../shared/lib/public-doc-manifest.mts";
+import { createRequire } from "node:module";
+
+const PUBLIC_DOC_SOURCE_FILES = createRequire(import.meta.url)("../../shared/lib/public-doc-manifest.json");
 
 function uniqueSorted(values) {
   return [...new Set(values)].sort();
@@ -49,7 +51,7 @@ export const DEPLOY_IMPACT_REGISTRY = {
     sharedExcludedPaths: [
       "shared/lib/pharosville-api-contract.ts",
       "shared/lib/public-docs.ts",
-      "shared/lib/public-doc-manifest.mts",
+      "shared/lib/public-doc-manifest.json",
       "shared/types/pharosville.ts",
     ],
     sharedExcludedPrefixes: ["shared/data/funding/", "shared/lib/selector/"],
@@ -67,7 +69,7 @@ export const DEPLOY_IMPACT_REGISTRY = {
     sharedExcludedPaths: [
       "shared/lib/pharosville-api-contract.ts",
       "shared/lib/public-docs.ts",
-      "shared/lib/public-doc-manifest.mts",
+      "shared/lib/public-doc-manifest.json",
       "shared/types/pharosville.ts",
     ],
     sharedExcludedPrefixes: ["shared/data/funding/", "shared/lib/selector/"],
@@ -154,7 +156,7 @@ export const GENERATED_ARTIFACT_REGISTRY = [
     phase: 0,
     reproducibility: "git-history-derived",
     script: "scripts/maintenance/generate-docs-metadata.ts",
-    sourcePaths: [...PUBLIC_DOC_SOURCE_PATHS, "shared/lib/public-doc-manifest.mts", "shared/lib/public-docs.ts"],
+    sourcePaths: [...PUBLIC_DOC_SOURCE_PATHS, "shared/lib/public-doc-manifest.json", "shared/lib/public-docs.ts"],
   }),
   generatedArtifact({
     id: "depeg-event-search-data",

--- a/shared/lib/public-doc-manifest.json
+++ b/shared/lib/public-doc-manifest.json
@@ -1,5 +1,4 @@
-/** Source filenames for the public /docs routes. */
-export const PUBLIC_DOC_SOURCE_FILES = [
+[
   "api-reference.md",
   "architecture.md",
   "data-flow-map.md",
@@ -20,5 +19,5 @@ export const PUBLIC_DOC_SOURCE_FILES = [
   "shadow-stablecoins.md",
   "design-context.md",
   "design-language.md",
-  "design-tokens.md",
-] as const;
+  "design-tokens.md"
+]

--- a/shared/lib/public-docs.ts
+++ b/shared/lib/public-docs.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_DOC_SOURCE_FILES } from "./public-doc-manifest.mts";
+import PUBLIC_DOC_SOURCE_FILES from "./public-doc-manifest.json";
 
 export const DOC_GROUPS = ["system", "methodology", "design"] as const;
 export type DocGroup = (typeof DOC_GROUPS)[number];


### PR DESCRIPTION
Follow-up to #952: the merged deploy run failed in pages-release.

1. Next's webpack has no loader for .mts — importing the public-doc manifest from shared/lib/public-docs.ts broke the production build. The manifest is now JSON (webpack-native; the .mjs automation registry loads it via createRequire).
2. The release data refresh consumed the generated stablecoin catalog before any compile-input artifacts existed (setup bootstrap is disabled), so the public-dataset refresh fail-opened to committed data. Compile-input artifacts are now materialized in a dedicated step before the refresh; the build step keeps only the post-refresh lifecycle, and the workflow-scope test pins the ordering.

Verified locally: full clean production build (prebuild lifecycle selection, next build --webpack, postbuild) plus classify-deploy-changes and ci-workflow-scope focused tests; root typecheck; registry standalone import.