### PR TITLE
ci(gitleaks): pin EUTBL Soroban fixture by fingerprint

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -112,17 +112,3 @@ regexes = [
   '''0x6a4854078428eea517e8013827cba9f90583f8a9fdf8610c8791d1b04feb6a3eee428bf506c98ead1e870918f26a1d41f5bfb792b1e4f331679d1ad3e527326f''',
 ]
 paths = ['''(?:^|/)shared/data/stablecoins/domains/risk-review/usdcx-movement\.json$''']
-
-# Stellar Soroban contract identifiers are StrKey-encoded: `C` plus exactly 55
-# base32 characters, optionally prefixed by their asset code as `CODE-C...`.
-# They are public on-chain identifiers exactly like the EVM and Solana
-# carve-outs above; DEX census fixtures and curated rows cite them verbatim,
-# and their base32 entropy trips the generic-api-key rule when the surrounding
-# variable or key mentions "token". The uppercase RFC 4648 base32 alphabet
-# (A-Z, 2-7) plus the fixed C prefix and exact length keep this narrow: a real
-# generic credential is effectively never shaped like a StrKey contract id.
-[[allowlists]]
-description = "Stellar Soroban StrKey contract identifiers are public on-chain identifiers, not secrets"
-targetRules = ["generic-api-key"]
-regexTarget = "secret"
-regexes = ['''^(?:[A-Z0-9]{1,12}-)?C[A-Z2-7]{55}$''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -292,3 +292,9 @@ d4efe6c590e4429387ea91a9b4b73bad760042e4:shared/data/safety-score-v9/transfer-re
 3717154f858c688984acb81d10f95fa3ecd849f4:worker/src/cron/reserve-adapters/erc4626-single-asset.ts:generic-api-key:739
 3717154f858c688984acb81d10f95fa3ecd849f4:worker/src/cron/reserve-adapters/erc4626-single-asset.ts:generic-api-key:741
 62c013cafc9e0d2420e5a12ffd68aa9e2f5434a2:worker/src/cron/reserve-adapters/usdrif-rif.ts:generic-api-key:28
+
+# Public EUTBL Soroban StrKey contract identifier (CODE-C... form) in the
+# Horizon census-scope test fixture, not a credential. Same finding in the
+# release-branch commit and in its squash-merge to main.
+bbdd0cb8933579fb83586d8fd8901acfbf52ba5a:worker/src/cron/dex-discovery/__tests__/crawl-horizon-pools.test.ts:generic-api-key:166
+5489cf1d57362cbc30fa2d95995819d1afc97d62:worker/src/cron/dex-discovery/__tests__/crawl-horizon-pools.test.ts:generic-api-key:166


### PR DESCRIPTION
Replaces the Stellar StrKey shape carve-out from #969 with exact `.gitleaksignore` fingerprints (release-branch commit + squash-merge commit), restoring full `generic-api-key` sensitivity for StrKey-shaped values. Verified locally: gitleaks over the merge range reports no leaks with the restored config.