### PR TITLE
fix(frontend): clear nightly navigation lint failures

### DIFF
--- a/src/app/methodology/sections/core/safety-scores-overview.tsx
+++ b/src/app/methodology/sections/core/safety-scores-overview.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   METHODOLOGY_LINK_CLASS,
   MethodologyFacts,
@@ -138,7 +139,7 @@ export function SafetyScoresOverview() {
       </p>
       <p className="text-xs text-muted-foreground">
         See also:{" "}
-        <a href="/methodology/scoring-changelog/" className={METHODOLOGY_LINK_CLASS}>Safety Score changelog</a>
+        <Link href="/methodology/scoring-changelog/" className={METHODOLOGY_LINK_CLASS}>Safety Score changelog</Link>
         {" · "}
         <a href="#pegscore-dews-methodology" className={METHODOLOGY_LINK_CLASS}>PegScore + DEWS</a>
         {" · "}

--- a/src/components/__tests__/ops-shell.test.tsx
+++ b/src/components/__tests__/ops-shell.test.tsx
@@ -79,6 +79,7 @@ describe("OpsShell", () => {
       "#ops-main-content",
     );
     expect(screen.getByRole("link", { name: "Reliability" }).className).toContain("min-h-11");
+    expect(screen.getByRole("link", { name: "Sign out" }).getAttribute("href")).toBe("/cdn-cgi/access/logout");
     expect(screen.getByRole("button", { name: "Dark mode" }).className).toContain("size-11");
     expect(scrollToMock).toHaveBeenCalledWith(expect.objectContaining({ behavior: "auto" }));
   });

--- a/src/components/ops-shell.tsx
+++ b/src/components/ops-shell.tsx
@@ -102,10 +102,6 @@ export function OpsShell({ children }: { children: ReactNode }) {
 
   if (!opsUiHost) return <OpsPublicHostGate />;
 
-  const handleSignOut = () => {
-    window.location.assign("/cdn-cgi/access/logout");
-  };
-
   return (
     <div
       className="min-h-screen overflow-x-clip bg-background"
@@ -156,15 +152,14 @@ export function OpsShell({ children }: { children: ReactNode }) {
             >
               {isDark ? <Sun className="size-4" aria-hidden="true" /> : <Moon className="size-4" aria-hidden="true" />}
             </button>
-            <button
-              type="button"
-              onClick={handleSignOut}
+            <a
+              href="/cdn-cgi/access/logout"
               className="pharos-focus-ring inline-flex min-h-11 items-center gap-2 rounded-md px-2.5 text-xs font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground"
               title="Sign out"
             >
               <LogOut className="size-4" aria-hidden="true" />
               <span className="hidden sm:inline">Sign out</span>
-            </button>
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- use Next Link for the internal methodology changelog route
- use a native anchor for the Cloudflare Access logout endpoint
- cover the logout target in the OpsShell component test

## Validation

- npm run lint
- npx vitest run src/components/__tests__/ops-shell.test.tsx
- npm run check:generated-artifacts
- npm run check:pr -- --base=origin/main (23 files, 364 tests)