### PR TITLE
Use canonical trailing-slash methodology hrefs in the Aug 24-30 changelog

### DIFF
--- a/src/data/changelogs/2026-08-30.ts
+++ b/src/data/changelogs/2026-08-30.ts
@@ -12,21 +12,21 @@ export const entry: ChangelogEntry = {
       tag: "feature",
       description:
         "Safety Score v9.44 and v9.45 separated a measured zero from an unproven settlement bound: an open queue with no proven completion bound now floors Exit under the unverified ceiling instead of grading F.",
-      href: "/methodology/scoring-changelog",
+      href: "/methodology/scoring-changelog/",
     },
     {
       label: "Reserve evidence gates",
       tag: "feature",
       description:
         "V9 9.4 through 9.43 split reserve classification from composition freshness, let an audited composition survive a stale feed on its own rung, and bounded Tether's feed by its actual disclosure cadence.",
-      href: "/methodology/scoring-changelog",
+      href: "/methodology/scoring-changelog/",
     },
     {
       label: "Redemption backstop v4.4",
       tag: "feature",
       description:
         "The standalone redemption route now publishes unestablished capacity and stays unrated when an open queue's settlement bound is unproven; paused routes keep their measured impairment.",
-      href: "/methodology/redemption-backstop-changelog",
+      href: "/methodology/redemption-backstop-changelog/",
     },
     {
       label: "Orbital Safety Map",
@@ -45,7 +45,7 @@ export const entry: ChangelogEntry = {
       tag: "infra",
       description:
         "Pricing moved 6.208 to 6.213: Pyth retired, the DexScreener breaker unlatched on partial success, VUSD and HCHF recovered, and delisted NAV vaults now price through their protocol-redeem route.",
-      href: "/methodology/pricing-pipeline-changelog",
+      href: "/methodology/pricing-pipeline-changelog/",
     },
     {
       label: "Leaner codebase",


### PR DESCRIPTION
Fixes the `pages-release` failure on `main` from run [33298166744](https://github.com/TokenBrice/pharos-watch/actions/runs/33298166744).

`check-seo-static.mjs` enforces the canonical trailing slash on internal anchors. The Aug 24–30 entry (#982) linked its four methodology references without one, so `/changelog/` rendered `/methodology/scoring-changelog` and the SEO gate failed before the release marker was written — no Pages deployment happened.

```
ERROR: /changelog/: internal anchor href omits canonical trailing slash: /methodology/scoring-changelog (use /methodology/scoring-changelog/)
```

This matches the convention every other rendered entry already uses (46 of 48 existing hrefs carry the slash).

## Verification

Local production-export rehearsal of the exact failing lane:

- `npm run build` — clean export
- `npm run seo:check` — `OK: Checked 1250 HTML pages in out/`, `OK: SEO static checks passed`

## Note

Two older entries carry the same slashless form (`/methodology/pricing-pipeline-changelog`, `/methodology/redemption-backstop-changelog`). They did not trip the gate because those entries are not rendered on the current `/changelog/` page, but they are latent and worth a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrKVT7Su9MAQnsgqqWuSF7