### PR TITLE
chore(deps): decouple root workspace from @cloudflare/workers-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,6 @@ updates:
     open-pull-requests-limit: 3
     rebase-strategy: "disabled"
     ignore:
-      # 5.20260821.1+ injects global Node-compat shims (declare const
-      # Buffer: any, process, setImmediate) that collide with @types/node
-      # in the root typecheck project shared by functions/ and scripts/.
-      # The worker workspace pins its own copy and orders resolution via
-      # tsconfig "types", so only the root copy is held back.
-      - dependency-name: "@cloudflare/workers-types"
       - dependency-name: "eslint"
         update-types:
           - "version-update:semver-major"
@@ -34,6 +28,7 @@ updates:
           - "patch"
   - package-ecosystem: "npm"
     directory: "/worker"
+    # Worker types float freely now that the root carries no copy.
     schedule:
       interval: "weekly"
     cooldown:

--- a/functions/__tests__/helpers/mock-kv.ts
+++ b/functions/__tests__/helpers/mock-kv.ts
@@ -1,4 +1,4 @@
-import type { KVNamespace, KVNamespaceGetOptions } from "@cloudflare/workers-types";
+import type { KVNamespace, KVNamespaceGetOptions } from "@shared/types/cloudflare-runtime";
 
 export interface RecordedPutCall {
   key: string;

--- a/functions/__tests__/safety-map-manifest.test.ts
+++ b/functions/__tests__/safety-map-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { KVNamespace } from "@cloudflare/workers-types";
+import type { KVNamespace } from "@shared/types/cloudflare-runtime";
 import type { SafetyMapContext } from "../lib/safety-map";
 import { makeKV } from "./helpers/mock-kv";
 import { onRequest } from "../safety-scores/map.json.ts";

--- a/functions/__tests__/selector-snapshot.test.ts
+++ b/functions/__tests__/selector-snapshot.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { D1Database, D1PreparedStatement, D1Result, KVNamespace } from "@cloudflare/workers-types";
+import type { D1Database, D1PreparedStatement, D1Result, KVNamespace } from "@shared/types/cloudflare-runtime";
 import { makeKV, type TestKVNamespace } from "./helpers/mock-kv";
 import { makePagesProxyContext } from "./helpers/pages-context";
 import {

--- a/functions/lib/request-attribution.ts
+++ b/functions/lib/request-attribution.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from "@cloudflare/workers-types";
+import type { D1Database } from "@shared/types/cloudflare-runtime";
 import {
   REQUEST_ATTRIBUTION_PRUNE_INTERVAL_SEC,
   REQUEST_ATTRIBUTION_RETENTION_DAYS,

--- a/functions/lib/safety-map.ts
+++ b/functions/lib/safety-map.ts
@@ -1,4 +1,4 @@
-import type { KVNamespace } from "@cloudflare/workers-types";
+import type { KVNamespace } from "@shared/types/cloudflare-runtime";
 
 export interface SafetyMapEnv {
   SELECTOR_SNAPSHOTS?: KVNamespace;

--- a/functions/lib/site-api-env.ts
+++ b/functions/lib/site-api-env.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from "@cloudflare/workers-types";
+import type { D1Database } from "@shared/types/cloudflare-runtime";
 import { getRuntimeActiveEnvKeys, getRuntimeEnvKeys } from "@shared/lib/env-contract";
 import { getConfiguredValue, hasConfiguredValue } from "@shared/lib/env-utils";
 import { SITE_API_ORIGIN as CANONICAL_SITE_API_ORIGIN } from "@shared/lib/runtime-origins";

--- a/functions/selector-snapshot/[[path]].ts
+++ b/functions/selector-snapshot/[[path]].ts
@@ -1,4 +1,4 @@
-import type { D1Database, KVNamespace } from "@cloudflare/workers-types";
+import type { D1Database, KVNamespace } from "@shared/types/cloudflare-runtime";
 import {
   SELECTOR_SNAPSHOT_MAX_PAYLOAD_BYTES,
   SELECTOR_SNAPSHOT_TTL_SECONDS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "4.13.0",
-        "@cloudflare/workers-types": "5.20260730.1",
         "@playwright/test": "1.62.1",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/react": "^16.3.0",
@@ -568,13 +567,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260730.1.tgz",
-      "integrity": "sha512-3e1cBXcPTwXBk2ur0CfxZKQKL6X7vUZlOn1R7VYU0zZVJcSKFcq1AoOZM+ps0LuL0uTAxdcLg+qwXrBXVu+UuQ==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,6 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "4.13.0",
-    "@cloudflare/workers-types": "5.20260730.1",
     "@playwright/test": "1.62.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/react": "^16.3.0",

--- a/scripts/maintenance/register-telegram.ts
+++ b/scripts/maintenance/register-telegram.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env tsx
-/// <reference types="@cloudflare/workers-types" />
 /**
  * Manual recovery tool for forcing Telegram Bot API state outside the
  * Worker's 15-minute reconciliation loop. Replaces three shell scripts that

--- a/shared/test-utils/mock-d1.ts
+++ b/shared/test-utils/mock-d1.ts
@@ -1,3 +1,5 @@
+import type { D1Database, D1PreparedStatement } from "@shared/types/cloudflare-runtime";
+
 /**
  * Lightweight D1 mock for API contract tests.
  * Returns canned row data based on SQL matching and optional bind matching.

--- a/shared/types/cloudflare-runtime.d.ts
+++ b/shared/types/cloudflare-runtime.d.ts
@@ -1,0 +1,286 @@
+/*! *****************************************************************************
+Copyright (c) Cloudflare. All rights reserved.
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+/**
+ * Vendored from @cloudflare/workers-types@5.20260730.1.
+ *
+ * This shared type-only module exists so the root workspace carries no
+ * dependency on the package (its >=5.20260821 global Node-compat shims
+ * collide with @types/node in the root project). It lives under shared/types
+ * so shared test utilities remain a base layer and never import functions/.
+ * Extend only when functions/ code needs new surface; the upstream package
+ * wins on semantics.
+ */
+
+export interface KVNamespaceListKey<Metadata, Key extends string = string> {
+  name: Key;
+  expiration?: number;
+  metadata?: Metadata;
+}
+
+export type KVNamespaceListResult<Metadata, Key extends string = string> =
+  | {
+      list_complete: false;
+      keys: KVNamespaceListKey<Metadata, Key>[];
+      cursor: string;
+      cacheStatus: string | null;
+    }
+  | {
+      list_complete: true;
+      keys: KVNamespaceListKey<Metadata, Key>[];
+      cacheStatus: string | null;
+    };
+
+export interface KVNamespace<Key extends string = string> {
+  get(
+    key: Key,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<string | null>;
+  get(key: Key, type: "text"): Promise<string | null>;
+  get<ExpectedValue = unknown>(
+    key: Key,
+    type: "json",
+  ): Promise<ExpectedValue | null>;
+  get(key: Key, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+  get(key: Key, type: "stream"): Promise<ReadableStream | null>;
+  get(
+    key: Key,
+    options?: KVNamespaceGetOptions<"text">,
+  ): Promise<string | null>;
+  get<ExpectedValue = unknown>(
+    key: Key,
+    options?: KVNamespaceGetOptions<"json">,
+  ): Promise<ExpectedValue | null>;
+  get(
+    key: Key,
+    options?: KVNamespaceGetOptions<"arrayBuffer">,
+  ): Promise<ArrayBuffer | null>;
+  get(
+    key: Key,
+    options?: KVNamespaceGetOptions<"stream">,
+  ): Promise<ReadableStream | null>;
+  get(key: Array<Key>, type: "text"): Promise<Map<string, string | null>>;
+  get<ExpectedValue = unknown>(
+    key: Array<Key>,
+    type: "json",
+  ): Promise<Map<string, ExpectedValue | null>>;
+  get(
+    key: Array<Key>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<Map<string, string | null>>;
+  get(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"text">,
+  ): Promise<Map<string, string | null>>;
+  get<ExpectedValue = unknown>(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"json">,
+  ): Promise<Map<string, ExpectedValue | null>>;
+  list<Metadata = unknown>(
+    options?: KVNamespaceListOptions,
+  ): Promise<KVNamespaceListResult<Metadata, Key>>;
+  put(
+    key: Key,
+    value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+    options?: KVNamespacePutOptions,
+  ): Promise<void>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    type: "text",
+  ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Key,
+    type: "json",
+  ): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    type: "arrayBuffer",
+  ): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    type: "stream",
+  ): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"text">,
+  ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"json">,
+  ): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"arrayBuffer">,
+  ): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"stream">,
+  ): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Array<Key>,
+    type: "text",
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Array<Key>,
+    type: "json",
+  ): Promise<
+    Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>
+  >;
+  getWithMetadata<Metadata = unknown>(
+    key: Array<Key>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"text">,
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"json">,
+  ): Promise<
+    Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>
+  >;
+  delete(key: Key): Promise<void>;
+}
+
+export interface KVNamespaceListOptions {
+  limit?: number;
+  prefix?: string | null;
+  cursor?: string | null;
+}
+
+export interface KVNamespaceGetOptions<Type> {
+  type: Type;
+  cacheTtl?: number;
+}
+
+export interface KVNamespacePutOptions {
+  expiration?: number;
+  expirationTtl?: number;
+  // Upstream workers-types intentionally exposes untyped KV metadata.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  metadata?: any | null;
+}
+
+export interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
+  value: Value | null;
+  metadata: Metadata | null;
+  cacheStatus: string | null;
+}
+
+export interface D1Meta {
+  duration: number;
+  size_after: number;
+  rows_read: number;
+  rows_written: number;
+  last_row_id: number;
+  changed_db: boolean;
+  changes: number;
+  /**
+   * The region of the database instance that executed the query.
+   */
+  served_by_region?: string;
+  /**
+   * The three letters airport code of the colo that executed the query.
+   */
+  served_by_colo?: string;
+  /**
+   * True if-and-only-if the database instance that executed the query was the primary.
+   */
+  served_by_primary?: boolean;
+  timings?: {
+    /**
+     * The duration of the SQL query execution by the database instance. It doesn't include any network time.
+     */
+    sql_duration_ms: number;
+  };
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
+}
+
+export interface D1Response {
+  success: true;
+  meta: D1Meta & Record<string, unknown>;
+  error?: never;
+}
+
+export type D1Result<T = unknown> = D1Response & {
+  results: T[];
+};
+
+export interface D1ExecResult {
+  count: number;
+  duration: number;
+}
+
+export type D1SessionConstraint =
+  // Indicates that the first query should go to the primary, and the rest queries
+  // using the same D1DatabaseSession will go to any replica that is consistent with
+  // the bookmark maintained by the session (returned by the first query).
+  | "first-primary"
+  // Indicates that the first query can go anywhere (primary or replica), and the rest
+  // queries using the same D1DatabaseSession will go to any replica that is consistent
+  // with the bookmark maintained by the session (returned by the first query).
+  | "first-unconstrained";
+
+export type D1SessionBookmark = string;
+
+export interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+  exec(query: string): Promise<D1ExecResult>;
+  /**
+   * Creates a new D1 Session anchored at the given constraint or the bookmark.
+   * All queries executed using the created session will have sequential consistency,
+   * meaning that all writes done through the session will be visible in subsequent reads.
+   *
+   * @param constraintOrBookmark Either the session constraint or the explicit bookmark to anchor the created session.
+   */
+  withSession(
+    constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint,
+  ): D1DatabaseSession;
+  /**
+   * @deprecated dump() will be removed soon, only applies to deprecated alpha v1 databases.
+   */
+  dump(): Promise<ArrayBuffer>;
+}
+
+export interface D1DatabaseSession {
+  prepare(query: string): D1PreparedStatement;
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+  /**
+   * @returns The latest session bookmark across all executed queries on the session.
+   *          If no query has been executed yet, `null` is returned.
+   */
+  getBookmark(): D1SessionBookmark | null;
+}
+
+export interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(colName: string): Promise<T | null>;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+  all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+  raw<T = unknown[]>(options: {
+    columnNames: true;
+  }): Promise<[string[], ...T[]]>;
+  raw<T = unknown[]>(options?: { columnNames?: false }): Promise<T[]>;
+}


### PR DESCRIPTION
## Summary

Fixes the recurring source of broken dependabot /worker PRs (latest #985): the root workers-types devDependency was held back at 5.20260730.1 (newer versions' global Node-compat shims collide with @types/node in the root project), and that pin ERESOLVEs against wrangler's peerOptional range in dependabot's resolver, producing manifest-only PRs that fail npm ci.

- Vendors the KV/D1 interface surface functions/ uses into `shared/types/cloudflare-runtime.d.ts` (type-only, verbatim 5.20260730.1 signatures, upstream Apache-2.0 notice retained).
- Repoints 7 functions/ imports + `shared/test-utils/mock-d1.ts` (previously resolving via ambient globals leaked by a triple-slash reference in register-telegram.ts) to `@shared/types/cloudflare-runtime`.
- Deletes the root devDependency, regenerates the lock, removes the obsolete dependabot ignore entry; worker types float freely.

## Validation

- Clean `npm ci`; `typecheck`, `typecheck:worker`, `typecheck:tests` green; functions vitest 14 files / 215 tests; `check:pr --base=origin/main` green incl. critical-coverage gate.
- From-scratch two-manifest resolution proof: no ERESOLVE, so future /worker bumps regenerate the lock normally.
