### PR TITLE
fix(worker): neutral classification for deploy-interrupted cron children

### DIFF
--- a/worker/src/lib/__tests__/cron-leases-scheduled-slot.test.ts
+++ b/worker/src/lib/__tests__/cron-leases-scheduled-slot.test.ts
@@ -168,6 +168,7 @@ describe("runScheduledSlotWithFence", () => {
           finished_at: null,
           updated_at: now - 1800,
           metadata: null,
+          worker_version: "worker-v1",
         },
       ],
       leases: [
@@ -196,6 +197,7 @@ describe("runScheduledSlotWithFence", () => {
       slotStartedAt,
       owner: "slot-owner-b",
       staleAfterSec: 1200,
+      workerVersion: "worker-v2",
     });
 
     expect(result.status).toBe("ok");
@@ -208,6 +210,10 @@ describe("runScheduledSlotWithFence", () => {
         error: "scheduled slot heartbeat stale; child job progress abandoned",
       }),
     ]);
+    expect(JSON.parse(db.getRuns()[0]?.metadata ?? "{}")).toMatchObject({
+      slotWorkerVersion: "worker-v1",
+      reconciledByWorkerVersion: "worker-v2",
+    });
     expect(db.getProgress("sync-yield-data")).toBeUndefined();
     expect(db.getLease("sync-yield-data")).toBeUndefined();
     const slot = db.getSlot("hourlyYieldSync", slotStartedAt);

--- a/worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts
+++ b/worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts
@@ -428,4 +428,67 @@ describe("scheduled slot reconciliation against the current D1 schema", () => {
     });
     sqlite.close();
   });
+
+  it("classifies a zero-duration stale child as neutral when deployment changed the worker version", async () => {
+    const { sqlite, db } = createMigratedDb();
+    const nowSec = 1_772_004_000;
+    const slotStartedAt = nowSec - 3_600;
+    sqlite.prepare(
+      `INSERT INTO cron_slot_executions (
+       slot_key, slot_started_at, state, result_status, execution_owner,
+       started_at, finished_at, updated_at, metadata, execution_generation,
+       invocation_id, worker_version
+     ) VALUES ('halfHourlyMeasuredExecution', ?, 'running', NULL, 'slot-owner', ?, NULL, ?, NULL, 1,
+               'old-invocation', 'worker-old')`,
+    ).run(slotStartedAt, slotStartedAt, slotStartedAt);
+    sqlite.prepare(
+      `INSERT INTO cron_leases (job, lease_owner, lease_until, heartbeat_at, updated_at)
+       VALUES ('sync-cl-exit-depth', 'child-owner', ?, ?, ?)`,
+    ).run(nowSec - 60, nowSec - 1_800, nowSec - 1_800);
+    sqlite.prepare(
+      `INSERT INTO cron_run_progress (
+       job, started_at, updated_at, stage, items_done, items_total,
+       message, lease_owner, metadata, slot_started_at
+     ) VALUES ('sync-cl-exit-depth', ?, ?, 'lease-acquired', 0, NULL, 'Lease acquired', 'child-owner', NULL, ?)`,
+    ).run(slotStartedAt, slotStartedAt, slotStartedAt);
+
+    const summary = await sweepStaleScheduledSlotExecutions(db, {
+      nowSec,
+      staleAfterSec: 1_200,
+      slotKey: "halfHourlyMeasuredExecution",
+      reconcilerWorkerVersion: "worker-new",
+    });
+
+    expect(summary).toMatchObject({
+      slotsReconciled: 1,
+      syntheticCronRuns: 1,
+      progressRowsCleared: 1,
+      leasesCleared: 1,
+    });
+    expect(sqlite.prepare(
+      `SELECT status, error
+         FROM cron_runs
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get()).toEqual({ status: "skipped_neutral", error: null });
+    expect(sqlite.prepare(
+      `SELECT outcome, error, productive
+         FROM worker_producer_history
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get()).toEqual({ outcome: "skipped_neutral", error: null, productive: 0 });
+    const runRow = sqlite.prepare(
+      `SELECT metadata
+         FROM cron_runs
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get() as { metadata: string } | undefined;
+    const metadata = JSON.parse(String(runRow?.metadata ?? "{}")) as Record<string, unknown>;
+    expect(metadata).toMatchObject({
+      failureCategory: "platform-interrupted",
+      childDisposition: "interrupted-by-deploy",
+      interruptedByWorkerVersionChange: true,
+      activeDurationMs: 0,
+      slotWorkerVersion: "worker-old",
+      reconciledByWorkerVersion: "worker-new",
+    });
+    sqlite.close();
+  });
 });

--- a/worker/src/lib/scheduled-slot-fence.ts
+++ b/worker/src/lib/scheduled-slot-fence.ts
@@ -479,6 +479,7 @@ async function claimScheduledSlotExecution(
           generation: existing.execution_generation + 1,
           state: "running",
         },
+        workerVersion,
       );
       staleSlotTakeover.reconciliation = reconciliation;
       await runWithOverloadRetry(() =>

--- a/worker/src/lib/scheduled-slot-reconciliation.ts
+++ b/worker/src/lib/scheduled-slot-reconciliation.ts
@@ -224,10 +224,25 @@ async function insertSyntheticStaleCronRun(
   const startedAt = progress.started_at || slot.started_at || slot.slot_started_at;
   const activeDurationMs = Math.max(0, progress.updated_at - startedAt) * 1000;
   const reconciliationDelayMs = Math.max(0, nowSec - progress.updated_at) * 1000;
-  const error = "scheduled slot heartbeat stale; child job progress abandoned";
+  // Progress timestamps are second-resolution. A zero-duration child has no
+  // progress beyond its startup second, so a known version change is strong
+  // evidence that the isolate was interrupted by deployment before it could
+  // do useful work.
+  // Keep the neutral classification fail-closed when either version is absent
+  // or unchanged: those cases can still be an in-place kill or a real fault.
+  const interruptedByWorkerDeploy =
+    progress.updated_at === startedAt
+    && slot.worker_version != null
+    && reconcilerWorkerVersion != null
+    && slot.worker_version !== reconcilerWorkerVersion;
+  const status = interruptedByWorkerDeploy ? "skipped_neutral" : "error";
+  const outcome = interruptedByWorkerDeploy ? "skipped_neutral" : "abandoned";
+  const error = interruptedByWorkerDeploy ? null : "scheduled slot heartbeat stale; child job progress abandoned";
   const metadata = JSON.stringify({
     reason: "stale-slot-reconciled",
-    failureCategory: "platform-abandoned",
+    failureCategory: interruptedByWorkerDeploy ? "platform-interrupted" : "platform-abandoned",
+    childDisposition: interruptedByWorkerDeploy ? "interrupted-by-deploy" : "abandoned",
+    interruptedByWorkerVersionChange: interruptedByWorkerDeploy,
     slotKey: slot.slot_key,
     slotStartedAt: slot.slot_started_at,
     slotOwner: slot.execution_owner,
@@ -268,7 +283,7 @@ async function insertSyntheticStaleCronRun(
            (job, started_at, duration_ms, status, error, item_count, metadata, slot_started_at, idempotency_key,
             schedule_key, producer_path, producer_kind, invocation_id, worker_version,
             productive, publication_count, calendar_period)
-         SELECT ?, ?, ?, 'error', ?, NULL, ?, ?, ?, ?, ?, 'scheduled-job', ?, ?, 0, 0, NULL
+         SELECT ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 'scheduled-job', ?, ?, 0, 0, NULL
           WHERE NOT EXISTS (
             SELECT 1 FROM cron_runs WHERE job = ? AND slot_started_at = ?
           )
@@ -291,6 +306,7 @@ async function insertSyntheticStaleCronRun(
         progress.job,
         startedAt,
         activeDurationMs,
+        status,
         error,
         metadata,
         slot.slot_started_at,
@@ -329,11 +345,14 @@ async function insertSyntheticStaleCronRun(
     // Preserve the last durable child heartbeat as the logical terminal time.
     // Reconciliation time stays in metadata and must not outrank a newer run.
     completedAt: progress.updated_at,
-    outcome: "abandoned",
+    outcome,
     itemCount: null,
     metadata,
     error,
-    productivity: { productive: false, reason: "platform-abandoned" },
+    productivity: {
+      productive: false,
+      reason: interruptedByWorkerDeploy ? "platform-interrupted-by-deploy" : "platform-abandoned",
+    },
   });
   return inserted;
 }


### PR DESCRIPTION
Production follow-up to #991: sync-cl-exit-depth reconciled as error/abandoned at 0ms during the Worker switchover because reconciliation ignored the version evidence it already carried. Zero-duration stale children with provably differing slot/reconciler worker versions now record skipped_neutral with platform-interrupted metadata; missing/equal versions stay fail-closed as error. Includes regression tests for both classifications. Verified: worker typecheck, cron-sync/connections, 3,400 worker lib tests.