### PR TITLE
fix(worker): bound deploy-interrupt cron classification with death-correlation and version-first-seen evidence

### DIFF
--- a/worker/src/__tests__/index.scheduled.test.ts
+++ b/worker/src/__tests__/index.scheduled.test.ts
@@ -390,6 +390,52 @@ import {
 describe("worker.scheduled", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    cronMocks.recordScheduledWorkerVersionFirstSeen.mockImplementation(async () => undefined);
+  });
+
+  it("attempts the worker-version marker write once per isolate", async () => {
+    const markerWrite = vi.fn(async () => undefined);
+    let attemptedInIsolate = false;
+    cronMocks.recordScheduledWorkerVersionFirstSeen.mockImplementation(async () => {
+      if (attemptedInIsolate) return;
+      attemptedInIsolate = true;
+      await markerWrite();
+    });
+    const env = makeScheduledEnv();
+
+    for (const [cron, scheduledTime] of [
+      ["9 * * * *", Date.parse("2026-08-30T12:09:00Z")],
+      ["24 * * * *", Date.parse("2026-08-30T12:24:00Z")],
+    ] as const) {
+      const { ctx, waits } = makeExecutionContext();
+      await worker.scheduled({ cron, scheduledTime } as ScheduledEvent, env, ctx);
+      await Promise.all(waits);
+    }
+
+    expect(cronMocks.recordScheduledWorkerVersionFirstSeen).toHaveBeenCalledTimes(2);
+    expect(markerWrite).toHaveBeenCalledTimes(1);
+    expect(cronMocks.runScheduledSlotWithFence).toHaveBeenCalledTimes(2);
+  }, 30_000);
+
+  it("continues the scheduled lane when the worker-version marker write fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    cronMocks.recordScheduledWorkerVersionFirstSeen.mockRejectedValueOnce(new Error("D1 marker unavailable"));
+    const env = makeScheduledEnv();
+    const { ctx, waits } = makeExecutionContext();
+
+    await expect(worker.scheduled(
+      {
+        cron: "9 * * * *",
+        scheduledTime: Date.parse("2026-08-30T12:09:00Z"),
+      } as ScheduledEvent,
+      env,
+      ctx,
+    )).resolves.toBeUndefined();
+    await Promise.all(waits);
+
+    expect(cronMocks.runScheduledSlotWithFence).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("smokes every configured scheduled trigger without live provider fetches", async () => {

--- a/worker/src/__tests__/index.scheduled.test.ts
+++ b/worker/src/__tests__/index.scheduled.test.ts
@@ -160,6 +160,7 @@ const cronMocks = vi.hoisted(() => ({
   }),
   getCache: vi.fn(async () => null),
   setCache: vi.fn(async () => undefined),
+  recordScheduledWorkerVersionFirstSeen: vi.fn(async () => undefined),
   shouldAttemptFetch: vi.fn(async () => true),
   recordOutcome: vi.fn(async () => undefined),
   reconcileTelegramCommandRegistration: vi.fn(async () => ({ attempted: false })),
@@ -316,6 +317,10 @@ vi.mock("../lib/db-cache", () => ({
   savePriceCache: vi.fn(async () => undefined),
 }));
 
+vi.mock("../lib/worker-version-first-seen", () => ({
+  recordScheduledWorkerVersionFirstSeen: cronMocks.recordScheduledWorkerVersionFirstSeen,
+}));
+
 vi.mock("../lib/cron-logger", async (importOriginal) => {
   const original = await importOriginal<typeof import("../lib/cron-logger")>();
   return {
@@ -428,6 +433,12 @@ describe("worker.scheduled", () => {
       }
 
       expect(cronMocks.runScheduledSlotWithFence).toHaveBeenCalledTimes(schedules.length);
+      expect(cronMocks.recordScheduledWorkerVersionFirstSeen).toHaveBeenCalledTimes(schedules.length);
+      expect(cronMocks.recordScheduledWorkerVersionFirstSeen).toHaveBeenCalledWith(
+        db,
+        "test-worker-version",
+        expect.any(Number),
+      );
       expect(cronMocks.runScheduledSlotWithFence.mock.calls.map((call) => call[1])).toEqual(
         schedules.map(([scheduleKey]) => scheduleKey),
       );

--- a/worker/src/handlers/scheduled.ts
+++ b/worker/src/handlers/scheduled.ts
@@ -10,6 +10,7 @@ import {
   type ScheduledSlotExecutionOptions,
 } from "../lib/scheduled-slot-fence";
 import { waitForV9MemoryLaneRelease } from "../lib/v9-slot-window";
+import { recordScheduledWorkerVersionFirstSeen } from "../lib/worker-version-first-seen";
 import { createScheduledRuntimeContext, type ScheduledRuntimeContext } from "./scheduled/context";
 import type { ScheduledSlotSummary } from "./scheduled/slot-summary";
 
@@ -161,6 +162,15 @@ export async function handleScheduledEvent(
     slotStartedAt,
     slotBudgetStartedAtMs,
   });
+  try {
+    await recordScheduledWorkerVersionFirstSeen(
+      env.DB,
+      runtime.workerVersion,
+      Math.floor(slotBudgetStartedAtMs / 1000),
+    );
+  } catch (error) {
+    logWorkerEventArgs("handler", "warn", "[cron-slot] Failed to record worker version first-seen time:", error);
+  }
 
   let slotResult;
   try {

--- a/worker/src/lib/__tests__/db-cache.test.ts
+++ b/worker/src/lib/__tests__/db-cache.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getPriceCache, readCacheWithPolicy, savePriceCache } from "../db-cache";
+import { createLatestSchemaSqlite } from "../../test-helpers/latest-schema-sqlite";
+import { getPriceCache, readCacheWithPolicy, savePriceCache, setCacheIfAbsent } from "../db-cache";
 
 interface FullPriceCacheRow {
   asset_id: string;
@@ -13,6 +14,19 @@ interface FullPriceCacheRow {
   agree_sources_json: string | null;
   consensus_sources_json: string | null;
 }
+
+describe("setCacheIfAbsent", () => {
+  it("preserves the first value and timestamp on a key conflict", async () => {
+    const { sqlite, db } = createLatestSchemaSqlite();
+
+    expect(await setCacheIfAbsent(db, "write-once", "first", 100)).toBe(true);
+    expect(await setCacheIfAbsent(db, "write-once", "second", 200)).toBe(false);
+    expect(sqlite.prepare(
+      "SELECT value, updated_at FROM cache WHERE key = 'write-once'",
+    ).get()).toEqual({ value: "first", updated_at: 100 });
+    sqlite.close();
+  });
+});
 
 function makeDb(options: {
   fullRows?: FullPriceCacheRow[];

--- a/worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts
+++ b/worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts
@@ -558,7 +558,7 @@ describe("scheduled slot reconciliation against the current D1 schema", () => {
   });
 
   it.each([
-    ["was first seen well after the joint death", 120],
+    ["was first seen five minutes after the joint death", 5 * 60],
     ["has no first-seen row", null],
   ])("keeps a joint slot and child death abandoned when the reconciler version %s", async (_reason, firstSeenDelaySec) => {
     const { sqlite, db } = createMigratedDb();

--- a/worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts
+++ b/worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts
@@ -429,7 +429,67 @@ describe("scheduled slot reconciliation against the current D1 schema", () => {
     sqlite.close();
   });
 
-  it("classifies a zero-duration stale child as neutral when deployment changed the worker version", async () => {
+  it("keeps a zero-duration child abandoned when its slot heartbeat continued before a deploy", async () => {
+    const { sqlite, db } = createMigratedDb();
+    const nowSec = 1_772_004_000;
+    const slotStartedAt = nowSec - 3_600;
+    sqlite.prepare(
+      `INSERT INTO cron_slot_executions (
+       slot_key, slot_started_at, state, result_status, execution_owner,
+       started_at, finished_at, updated_at, metadata, execution_generation,
+       invocation_id, worker_version
+     ) VALUES ('halfHourlyMeasuredExecution', ?, 'running', NULL, 'slot-owner', ?, NULL, ?, NULL, 1,
+               'old-invocation', 'worker-old')`,
+    ).run(slotStartedAt, slotStartedAt, slotStartedAt + 45);
+    sqlite.prepare(
+      `INSERT INTO cron_leases (job, lease_owner, lease_until, heartbeat_at, updated_at)
+       VALUES ('sync-cl-exit-depth', 'child-owner', ?, ?, ?)`,
+    ).run(nowSec - 60, nowSec - 1_800, nowSec - 1_800);
+    sqlite.prepare(
+      `INSERT INTO cron_run_progress (
+       job, started_at, updated_at, stage, items_done, items_total,
+       message, lease_owner, metadata, slot_started_at
+     ) VALUES ('sync-cl-exit-depth', ?, ?, 'lease-acquired', 0, NULL, 'Lease acquired', 'child-owner', NULL, ?)`,
+    ).run(slotStartedAt, slotStartedAt, slotStartedAt);
+
+    const summary = await sweepStaleScheduledSlotExecutions(db, {
+      nowSec,
+      staleAfterSec: 1_200,
+      slotKey: "halfHourlyMeasuredExecution",
+      reconcilerWorkerVersion: "worker-new",
+    });
+
+    expect(summary).toMatchObject({ slotsReconciled: 1, syntheticCronRuns: 1 });
+    expect(sqlite.prepare(
+      `SELECT status, error
+         FROM cron_runs
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get()).toEqual({
+      status: "error",
+      error: "scheduled slot heartbeat stale; child job progress abandoned",
+    });
+    expect(sqlite.prepare(
+      `SELECT outcome, error
+         FROM worker_producer_history
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get()).toEqual({
+      outcome: "abandoned",
+      error: "scheduled slot heartbeat stale; child job progress abandoned",
+    });
+    const runRow = sqlite.prepare(
+      `SELECT metadata
+         FROM cron_runs
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get() as { metadata: string } | undefined;
+    expect(JSON.parse(String(runRow?.metadata ?? "{}"))).toMatchObject({
+      failureCategory: "platform-abandoned",
+      childDisposition: "abandoned",
+      interruptedByWorkerVersionChange: false,
+    });
+    sqlite.close();
+  });
+
+  it("classifies a zero-duration stale child as neutral when its slot heartbeat stopped with it before a deploy", async () => {
     const { sqlite, db } = createMigratedDb();
     const nowSec = 1_772_004_000;
     const slotStartedAt = nowSec - 3_600;
@@ -445,6 +505,10 @@ describe("scheduled slot reconciliation against the current D1 schema", () => {
       `INSERT INTO cron_leases (job, lease_owner, lease_until, heartbeat_at, updated_at)
        VALUES ('sync-cl-exit-depth', 'child-owner', ?, ?, ?)`,
     ).run(nowSec - 60, nowSec - 1_800, nowSec - 1_800);
+    sqlite.prepare(
+      `INSERT INTO cache (key, value, updated_at)
+       VALUES ('worker-version-first-seen:worker-new', '{}', ?)`,
+    ).run(slotStartedAt + 5);
     sqlite.prepare(
       `INSERT INTO cron_run_progress (
        job, started_at, updated_at, stage, items_done, items_total,
@@ -488,6 +552,70 @@ describe("scheduled slot reconciliation against the current D1 schema", () => {
       activeDurationMs: 0,
       slotWorkerVersion: "worker-old",
       reconciledByWorkerVersion: "worker-new",
+      reconciledByWorkerVersionFirstSeenAt: slotStartedAt + 5,
+    });
+    sqlite.close();
+  });
+
+  it.each([
+    ["was first seen well after the joint death", 120],
+    ["has no first-seen row", null],
+  ])("keeps a joint slot and child death abandoned when the reconciler version %s", async (_reason, firstSeenDelaySec) => {
+    const { sqlite, db } = createMigratedDb();
+    const nowSec = 1_772_004_000;
+    const slotStartedAt = nowSec - 3_600;
+    sqlite.prepare(
+      `INSERT INTO cron_slot_executions (
+       slot_key, slot_started_at, state, result_status, execution_owner,
+       started_at, finished_at, updated_at, metadata, execution_generation,
+       invocation_id, worker_version
+     ) VALUES ('halfHourlyMeasuredExecution', ?, 'running', NULL, 'slot-owner', ?, NULL, ?, NULL, 1,
+               'old-invocation', 'worker-old')`,
+    ).run(slotStartedAt, slotStartedAt, slotStartedAt);
+    sqlite.prepare(
+      `INSERT INTO cron_leases (job, lease_owner, lease_until, heartbeat_at, updated_at)
+       VALUES ('sync-cl-exit-depth', 'child-owner', ?, ?, ?)`,
+    ).run(nowSec - 60, nowSec - 1_800, nowSec - 1_800);
+    sqlite.prepare(
+      `INSERT INTO cron_run_progress (
+       job, started_at, updated_at, stage, items_done, items_total,
+       message, lease_owner, metadata, slot_started_at
+     ) VALUES ('sync-cl-exit-depth', ?, ?, 'lease-acquired', 0, NULL, 'Lease acquired', 'child-owner', NULL, ?)`,
+    ).run(slotStartedAt, slotStartedAt, slotStartedAt);
+    if (firstSeenDelaySec != null) {
+      sqlite.prepare(
+        `INSERT INTO cache (key, value, updated_at)
+         VALUES ('worker-version-first-seen:worker-new', '{}', ?)`,
+      ).run(slotStartedAt + firstSeenDelaySec);
+    }
+
+    const summary = await sweepStaleScheduledSlotExecutions(db, {
+      nowSec,
+      staleAfterSec: 1_200,
+      slotKey: "halfHourlyMeasuredExecution",
+      reconcilerWorkerVersion: "worker-new",
+    });
+
+    expect(summary).toMatchObject({ slotsReconciled: 1, syntheticCronRuns: 1 });
+    expect(sqlite.prepare(
+      `SELECT status, error
+         FROM cron_runs
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get()).toEqual({
+      status: "error",
+      error: "scheduled slot heartbeat stale; child job progress abandoned",
+    });
+    const runRow = sqlite.prepare(
+      `SELECT metadata
+         FROM cron_runs
+        WHERE job = 'sync-cl-exit-depth'`,
+    ).get() as { metadata: string } | undefined;
+    expect(JSON.parse(String(runRow?.metadata ?? "{}"))).toMatchObject({
+      failureCategory: "platform-abandoned",
+      childDisposition: "abandoned",
+      interruptedByWorkerVersionChange: false,
+      reconciledByWorkerVersionFirstSeenAt:
+        firstSeenDelaySec == null ? null : slotStartedAt + firstSeenDelaySec,
     });
     sqlite.close();
   });

--- a/worker/src/lib/__tests__/worker-version-first-seen.test.ts
+++ b/worker/src/lib/__tests__/worker-version-first-seen.test.ts
@@ -1,0 +1,26 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { createLatestSchemaSqlite } from "../../test-helpers/latest-schema-sqlite";
+import {
+  getWorkerVersionFirstSeenAt,
+  recordScheduledWorkerVersionFirstSeen,
+} from "../worker-version-first-seen";
+
+describe("worker version first-seen persistence", () => {
+  it("attempts one write per isolate and preserves the first timestamp", async () => {
+    const { sqlite, db } = createLatestSchemaSqlite();
+
+    await recordScheduledWorkerVersionFirstSeen(db, null, 1_800_000_000);
+    await recordScheduledWorkerVersionFirstSeen(db, "worker-v2", 1_800_000_010);
+    await recordScheduledWorkerVersionFirstSeen(db, "worker-v2", 1_800_000_020);
+
+    expect(await getWorkerVersionFirstSeenAt(db, "worker-v2")).toBe(1_800_000_010);
+    expect((sqlite as DatabaseSync).prepare(
+      "SELECT key, updated_at FROM cache WHERE key = 'worker-version-first-seen:worker-v2'",
+    ).all()).toEqual([{
+      key: "worker-version-first-seen:worker-v2",
+      updated_at: 1_800_000_010,
+    }]);
+    sqlite.close();
+  });
+});

--- a/worker/src/lib/db-cache.ts
+++ b/worker/src/lib/db-cache.ts
@@ -107,6 +107,30 @@ export async function getCacheUpdatedAt(db: D1Database, key: string): Promise<nu
   return row?.updated_at ?? null;
 }
 
+export async function setCacheIfAbsent(
+  db: D1Database,
+  key: string,
+  value: string,
+  updatedAt: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  throwIfAborted(signal);
+  const result = await runWithOverloadRetry(
+    () =>
+      db
+        .prepare(
+          `INSERT INTO cache (key, value, updated_at) VALUES (?, ?, ?)
+           ON CONFLICT(key) DO NOTHING`,
+        )
+        .bind(key, value, updatedAt)
+        .run(),
+    3,
+    signal,
+  );
+  throwIfAborted(signal);
+  return (result.meta.changes ?? 0) > 0;
+}
+
 export interface CacheEntryWrite {
   key: string;
   value: string;

--- a/worker/src/lib/scheduled-slot-reconciliation.ts
+++ b/worker/src/lib/scheduled-slot-reconciliation.ts
@@ -7,6 +7,7 @@ import type { CronScheduleKey } from "@shared/lib/cron-jobs";
 import { runWithOverloadRetry } from "./d1-overload-retry";
 import { recordProducerOutcome } from "./producer-history";
 import { cronEventCacheKey, logCronEvent } from "./cron-logger";
+import { getWorkerVersionFirstSeenAt } from "./worker-version-first-seen";
 
 
 export interface StaleSlotExecutionArtifact {
@@ -102,6 +103,16 @@ export function getExpectedJobsForScheduledSlot(slotKey: string): readonly strin
 // this bound a dead child's lease keeps its slot un-reconcilable for the whole
 // TTL after an OOM kill.
 const CHILD_LEASE_HEARTBEAT_STALE_SEC = 5 * 60;
+// Slot policies heartbeat every 30-60 seconds (45 seconds for measured
+// execution), while the fence clamps custom cadences to at least 15 seconds.
+// Keep the deploy-interruption alignment window below the measured cadence so
+// even one later slot heartbeat disproves that the slot and child died together.
+const DEPLOY_INTERRUPTION_HEARTBEAT_ALIGNMENT_SEC = 15;
+// The measured-execution slot heartbeats every 45 seconds. A replacement
+// version first observed later than that cannot explain the joint heartbeat
+// stop and must not neutralize an earlier invocation failure.
+const DEPLOY_INTERRUPTION_FIRST_SEEN_MAX_DELAY_SEC = 45;
+const DEPLOY_INTERRUPTION_FIRST_SEEN_EARLY_SLACK_SEC = 15;
 
 export async function hasActiveChildLeaseForScheduledSlot(
   db: D1Database,
@@ -224,17 +235,32 @@ async function insertSyntheticStaleCronRun(
   const startedAt = progress.started_at || slot.started_at || slot.slot_started_at;
   const activeDurationMs = Math.max(0, progress.updated_at - startedAt) * 1000;
   const reconciliationDelayMs = Math.max(0, nowSec - progress.updated_at) * 1000;
-  // Progress timestamps are second-resolution. A zero-duration child has no
-  // progress beyond its startup second, so a known version change is strong
-  // evidence that the isolate was interrupted by deployment before it could
-  // do useful work.
-  // Keep the neutral classification fail-closed when either version is absent
-  // or unchanged: those cases can still be an in-place kill or a real fault.
-  const interruptedByWorkerDeploy =
+  // Progress timestamps are second-resolution. Treat a version change as a
+  // deploy interruption only when the old slot's own heartbeat also stopped
+  // with the child. A later slot heartbeat proves the isolate survived the
+  // child failure; missing or ambiguous timestamps remain abandoned.
+  const slotHeartbeatStoppedWithChild =
+    Number.isSafeInteger(slot.updated_at)
+    && slot.updated_at > 0
+    && Number.isSafeInteger(progress.updated_at)
+    && progress.updated_at > 0
+    && slot.updated_at < nowSec - CHILD_LEASE_HEARTBEAT_STALE_SEC
+    && Math.abs(slot.updated_at - progress.updated_at) <= DEPLOY_INTERRUPTION_HEARTBEAT_ALIGNMENT_SEC;
+  const correlatedDeathWithVersionDrift =
     progress.updated_at === startedAt
     && slot.worker_version != null
     && reconcilerWorkerVersion != null
-    && slot.worker_version !== reconcilerWorkerVersion;
+    && slot.worker_version !== reconcilerWorkerVersion
+    && slotHeartbeatStoppedWithChild;
+  const reconcilerWorkerVersionFirstSeenAt = correlatedDeathWithVersionDrift
+    ? await getWorkerVersionFirstSeenAt(db, reconcilerWorkerVersion)
+    : null;
+  const interruptedByWorkerDeploy =
+    correlatedDeathWithVersionDrift
+    && reconcilerWorkerVersionFirstSeenAt != null
+    && reconcilerWorkerVersionFirstSeenAt >= progress.updated_at - DEPLOY_INTERRUPTION_FIRST_SEEN_EARLY_SLACK_SEC
+    && reconcilerWorkerVersionFirstSeenAt <= progress.updated_at + DEPLOY_INTERRUPTION_FIRST_SEEN_MAX_DELAY_SEC
+    && reconcilerWorkerVersionFirstSeenAt <= nowSec;
   const status = interruptedByWorkerDeploy ? "skipped_neutral" : "error";
   const outcome = interruptedByWorkerDeploy ? "skipped_neutral" : "abandoned";
   const error = interruptedByWorkerDeploy ? null : "scheduled slot heartbeat stale; child job progress abandoned";
@@ -258,6 +284,7 @@ async function insertSyntheticStaleCronRun(
     // time of death) vs in-place kill (e.g. OOM) decidable from this row.
     slotWorkerVersion: slot.worker_version ?? null,
     reconciledByWorkerVersion: reconcilerWorkerVersion ?? null,
+    reconciledByWorkerVersionFirstSeenAt: reconcilerWorkerVersionFirstSeenAt,
   });
   const idempotencyKey = ["scheduled-slot-stale", slot.slot_key, slot.slot_started_at, progress.job, startedAt].join(
     ":",

--- a/worker/src/lib/scheduled-slot-reconciliation.ts
+++ b/worker/src/lib/scheduled-slot-reconciliation.ts
@@ -108,10 +108,10 @@ const CHILD_LEASE_HEARTBEAT_STALE_SEC = 5 * 60;
 // Keep the deploy-interruption alignment window below the measured cadence so
 // even one later slot heartbeat disproves that the slot and child died together.
 const DEPLOY_INTERRUPTION_HEARTBEAT_ALIGNMENT_SEC = 15;
-// The measured-execution slot heartbeats every 45 seconds. A replacement
-// version first observed later than that cannot explain the joint heartbeat
-// stop and must not neutralize an earlier invocation failure.
-const DEPLOY_INTERRUPTION_FIRST_SEEN_MAX_DELAY_SEC = 45;
+// The measured-execution slot heartbeats every 45 seconds. Allow one cadence
+// plus 15 seconds of timestamp/write slack; anything later cannot prove the
+// replacement version landed on top of the joint heartbeat stop.
+const DEPLOY_INTERRUPTION_FIRST_SEEN_MAX_DELAY_SEC = 60;
 const DEPLOY_INTERRUPTION_FIRST_SEEN_EARLY_SLACK_SEC = 15;
 
 export async function hasActiveChildLeaseForScheduledSlot(

--- a/worker/src/lib/worker-version-first-seen.ts
+++ b/worker/src/lib/worker-version-first-seen.ts
@@ -1,0 +1,36 @@
+import { getCacheUpdatedAt, setCacheIfAbsent } from "./db-cache";
+
+const WORKER_VERSION_FIRST_SEEN_PREFIX = "worker-version-first-seen:";
+
+let scheduledVersionFirstSeenAttemptedInIsolate = false;
+
+function workerVersionFirstSeenCacheKey(workerVersion: string): string {
+  return `${WORKER_VERSION_FIRST_SEEN_PREFIX}${workerVersion}`;
+}
+
+export async function recordScheduledWorkerVersionFirstSeen(
+  db: D1Database,
+  workerVersion: string | null | undefined,
+  firstSeenAt: number,
+): Promise<void> {
+  const version = workerVersion?.trim();
+  if (!version || !Number.isSafeInteger(firstSeenAt) || firstSeenAt <= 0) return;
+  if (scheduledVersionFirstSeenAttemptedInIsolate) return;
+  scheduledVersionFirstSeenAttemptedInIsolate = true;
+  await setCacheIfAbsent(
+    db,
+    workerVersionFirstSeenCacheKey(version),
+    JSON.stringify({ workerVersion: version, firstSeenAt }),
+    firstSeenAt,
+  );
+}
+
+export async function getWorkerVersionFirstSeenAt(
+  db: D1Database,
+  workerVersion: string | null | undefined,
+): Promise<number | null> {
+  const version = workerVersion?.trim();
+  if (!version) return null;
+  const firstSeenAt = await getCacheUpdatedAt(db, workerVersionFirstSeenCacheKey(version));
+  return Number.isSafeInteger(firstSeenAt) && (firstSeenAt ?? 0) > 0 ? firstSeenAt : null;
+}


### PR DESCRIPTION
Hardens #992's skipped_neutral path so version drift alone can never mask a genuine crash. Neutral now requires: zero-duration child, differing slot/reconciler versions, slot heartbeat and child progress dying within 15s of each other (a surviving 45s heartbeat proves the isolate outlived the child), and a write-once worker-version-first-seen KV marker placing the deploy inside the child's death window and before the sweep. Anything missing/late/ambiguous stays error/abandoned. No schema changes; marker rows self-heal from the next deploy. Verified: worker typecheck, 74 tests across 7 suites, cron-sync, cron-connections.