### PR TITLE
fix(safety-map): trust canonical score publications

### DIFF
--- a/.github/workflows/safety-map-refresh.yml
+++ b/.github/workflows/safety-map-refresh.yml
@@ -3,8 +3,6 @@
 # The workflow owns scheduling, credentials, runner setup, and artifact upload.
 # scripts/maintenance/publish-safety-score-map.ts owns the publication state
 # machine. Its load-bearing KV order is:
-#   safety-map:snapshot:YYYY-MM-DD
-#   safety-map:snapshot:latest
 #   safety-map:alt:latest
 #   safety-map:YYYY-MM-DD.png (then immediate byte readback verification)
 #   safety-map:latest.png
@@ -27,13 +25,7 @@ on:
     - cron: "20 2 * * *"
     - cron: "20 4 * * *"
     - cron: "20 6 * * *"
-  workflow_dispatch:
-    inputs:
-      accept_snapshot_transition:
-        description: Accept the current live snapshot as an audited methodology/census transition
-        required: false
-        default: false
-        type: boolean
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -72,26 +64,18 @@ jobs:
             exit 1
           fi
 
-      # KV listing doubles as the namespace/token probe. It also fetches the
-      # previous snapshot best-effort so the renderer can arm its delta guard.
+      # KV listing doubles as the namespace/token probe and lets scheduled
+      # retries skip a same-day publication that is already fresh.
       - name: Plan publication from live KV state
         id: plan
         env:
-          ACCEPT_SNAPSHOT_TRANSITION: ${{ inputs.accept_snapshot_transition || false }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.SAFETY_MAP_KV_TOKEN }}
           KV_NAMESPACE_ID: ${{ vars.SAFETY_MAP_KV_NAMESPACE_ID }}
-        run: |
-          set -euo pipefail
-          args=(
-            plan
-            "--event-name=${{ github.event_name }}"
-            "--out-dir=${MAP_OUT_DIR}"
-          )
-          if [ "${ACCEPT_SNAPSHOT_TRANSITION}" = "true" ]; then
-            args+=(--accept-snapshot-transition)
-          fi
-          npx tsx scripts/maintenance/publish-safety-score-map.ts "${args[@]}"
+        run: >-
+          npx tsx scripts/maintenance/publish-safety-score-map.ts plan
+          --event-name="${{ github.event_name }}"
+          --out-dir="${MAP_OUT_DIR}"
 
       - name: Render and validate publication files
         id: render
@@ -111,7 +95,7 @@ jobs:
           path: |
             ${{ env.MAP_OUT_DIR }}/latest.png
             ${{ env.MAP_OUT_DIR }}/latest.alt.json
-            ${{ env.MAP_OUT_DIR }}/latest.snapshot.json
+            ${{ env.MAP_OUT_DIR }}/latest.manifest.json
             ${{ env.MAP_OUT_DIR }}/kv-manifest.json
           if-no-files-found: error
           retention-days: 14

--- a/docs/safety-score-map.md
+++ b/docs/safety-score-map.md
@@ -20,10 +20,9 @@ One generator, one composition, two editions selected by `--edition`.
 | Trigger | Unattended, by the refresh workflow | Deliberate, by an operator |
 | Date treatment | Once in the footer | Issue lockup in the masthead plus footer provenance (the month reaches the archive name and alt text, not the poster) |
 | Default basename | `safety-score-map-latest` | `safety-score-map-<YYYY-MM>` |
-| Movers window | Since the previous snapshot | Month-boundary snapshots |
 | Published to | KV, and therefore the live route | Not published by any automation |
 
-The monthly edition is never inferred from the data clock. Archive and output naming use the **UTC run date**; visible date provenance uses the report-card capture clock (`asOfSec`). Without that split, a run on the first of a month over the previous month's data would file itself under the wrong month and collide with the existing monthly archive. The Movers window names the snapshot comparison baseline; that comparison currently feeds the delta guard and is not yet rendered on the poster.
+The monthly edition is never inferred from the data clock. Archive and output naming use the **UTC run date**; visible date provenance uses the report-card capture clock (`asOfSec`). Without that split, a run on the first of a month over the previous month's data would file itself under the wrong month and collide with the existing monthly archive.
 
 `--issue <n>` supplies the monthly issue number; it is a positive integer and applies to the monthly lockup only.
 
@@ -33,7 +32,7 @@ The monthly edition is never inferred from the data clock. Archive and output na
 
 Data comes from the keyed maintenance API — the V9 report cards, stablecoin list, and current Stability Index response — so `PHAROS_API_KEY` is required (env or `.env.local`), with `PHAROS_API_BASE` as an optional origin override. Supply is read through `getCirculatingRaw()` and treated as already USD-denominated. The PSI footer follows the same display rule as the Stability Index page: the rolling 24-hour level and band when both are available, labeled `24H AVG`; otherwise the raw current sample is labeled `RAW`. A missing, malformed, future-dated, or stale PSI reading fails the render instead of publishing an old regime.
 
-Beside the PNG, sharing its basename, the run writes `.svg` and `.html` (the rendered scene and its screenshot host), `.alt.json` (alt text plus the per-tier table), `.snapshot.json` (per-coin `{id, symbol, score, grade, mcap}` under a header of `{edition, date, publicationStatus, asOfSec, renderedAtSec, methodologyVersion, counts, mapSummary}`), and `.manifest.json`. The snapshot is both the movers baseline and the next run's delta-guard input.
+Beside the PNG, sharing its basename, the run writes `.svg` and `.html` (the rendered scene and its screenshot host), `.alt.json` (alt text plus the per-tier table), and `.manifest.json` (publication provenance, render counts, and the public `mapSummary`). The map keeps no historical score snapshot because comparing score movements is outside the renderer's responsibility.
 
 Every figure on the poster is computed from the fetched data. No headline number is a literal — under an unattended daily cadence a hardcoded figure becomes a published falsehood within days.
 
@@ -47,7 +46,7 @@ The two largest A-tier circles form one tangent hero pair whose area-weighted vi
 
 The generator exits non-zero rather than publishing something wrong. All of these are unconditional:
 
-- **Freshness and publication status.** The report-card capture must be future-free and under 48 hours old (the exact 48-hour boundary fails), and the API must label it `current`. The PSI sample must also be future-free and stay within the shared Stability Index endpoint freshness budget. A stalled or held producer must fail the job, not publish old scores or an old PSI regime under today's date.
+- **Canonical inputs.** Report cards must satisfy the canonical API schema. Their publication status and capture time are preserved as provenance but do not gate rendering: a valid held or aged Safety Score publication still renders. The PSI sample must remain future-free and within the shared Stability Index endpoint freshness budget because the poster presents it as current context.
 - **Input hygiene.** The response must have unique card IDs, finite scores in range, exact grade vocabulary, and score/grade agreement. Negative finite supply buckets fail closed before the supply join.
 - **Join coverage.** At least 95% of graded cards must join a list row with real supply, or the map is drawing legibility floors instead of data.
 - **Grade vocabulary.** An unrecognized grade letter fails; a silently dropped tier is worse than no map.
@@ -57,24 +56,16 @@ The generator exits non-zero rather than publishing something wrong. All of thes
 - **Fonts.** Each family is checked explicitly; `document.fonts.ready` resolves even when a face fails, and fallback metrics visibly change the publication typography.
 - **Raster size.** The screenshot must come back at exactly 3200x1800 (1600x900 at `deviceScaleFactor: 2`).
 
-One guard is skippable: the **day-over-day delta guard**, armed by `--previous-snapshot <path>`. It fails the run when the graded count falls more than 2% or the not-rated count moves more than 5 against the prior snapshot, and also checks per-tier counts, per-coin grade transitions, tier and leader supply, join identity, and missing-logo count. A missing path or no supplied baseline skips it with a warning, so a first run can bootstrap; a present but malformed baseline fails closed rather than being treated as absent.
-
-The tier-leader check tolerates an explained swap: a new tier leader passes when the prior snapshot's census already recorded the coin and its own supply moved within the same 25% tolerance. Near-tied coins trade the top spot on ordinary market movement (2026-08-29: a ~0.6% BUIDL/USYC gap in tier C flipped, failed both scheduled runs, and shipped the digest without the map), and a failed run never advances the snapshot baseline, so a hard identity check kept failing against the same stale leader. A leader the previous census never saw, or one whose supply moved more than 25%, still fails closed as a suspected join or scoring fault.
-
-An operator may accept a reviewed methodology or census transition through the manual workflow's `accept_snapshot_transition` input. The publication planner permits that flag only on `workflow_dispatch`, requires the current live snapshot to be readable, and records the acceptance in the run state and summary. The renderer still parses and validates that snapshot against the full current publication contract, then skips only the day-over-day comparisons; freshness, finite geometry, composition, header clearance, font, and raster-size guards remain mandatory. Scheduled runs cannot use this path, and normal tolerances are unchanged.
-
-The join-identity check applies only to coins present in both snapshots, and tolerates immaterial flips: a coin whose joined state changes in either direction (supply crossing zero, or its list row appearing/disappearing) is warned about and published from the current supply state — a coin that lost its join draws at the size floor, one that regained it draws at its real size — rather than failing the run, as long as at most 3 coins flip and their combined supply stays under 0.1% of the previous snapshot's mapped supply. Beyond either bound the run still fails closed. Census additions and removals are deliberately not join flips — they are bounded by the graded-count, tier-count, tier-supply and leader checks instead. The original check counted them, which failed the run the day after any coin entered the census (2026-08-26: `hollar-hydrated` moving NR → graded under methodology 9.44 blocked that day's publication and digest map) — and, because a failed run never advances `safety-map:snapshot:latest`, every later run kept failing against the same stale baseline until the census change was accommodated in code.
+There is deliberately no day-over-day score, grade, tier, leader, census, supply-movement, or missing-logo comparison. The Safety Score publication pipeline and its history own movement validation; the map's single responsibility is to render the canonical publication it receives. This prevents legitimate scoring or methodology changes from blocking the presentation surface.
 
 ## Publication
 
 `.github/workflows/safety-map-refresh.yml` owns checkout, credentials, scheduling, and artifact upload. `scripts/maintenance/publish-safety-score-map.ts` owns the tested operational state machine through explicit `plan`, `render`, `publish`, and `summary` phases. `plan --dry-run` inspects live KV state and prints the same-day decision without rendering or writing KV; it still requires the purpose-scoped KV credentials because a useful plan cannot guess at live state.
 
-The workflow reads `safety-map:snapshot:latest` to arm the delta guard, renders the daily edition, builds a KV manifest from the snapshot header, and publishes. Key order is load-bearing:
+The workflow reads the live manifest only to decide whether a scheduled slot has already produced a sufficiently fresh same-day map, renders the daily edition when needed, builds the compact KV manifest from the renderer's manifest sidecar, and publishes. Key order is load-bearing:
 
 | Key | Contents |
 | --- | --- |
-| `safety-map:snapshot:YYYY-MM-DD` | Dated snapshot, archival |
-| `safety-map:snapshot:latest` | Rolling pointer, read by the next run |
 | `safety-map:alt:latest` | Alt text and the per-tier table |
 | `safety-map:YYYY-MM-DD.png` | Dated image — the URL the digest embeds |
 | `safety-map:latest.png` | Same bytes, stable URL for the site |
@@ -90,7 +81,7 @@ Failure surfaces as a red run and a GitHub notification. It does **not** page an
 
 `vars.SAFETY_MAP_KV_NAMESPACE_ID` and `secrets.SAFETY_MAP_KV_TOKEN` are provisioned. The token is scoped to *Workers KV Storage: Edit* on that one namespace and is deliberately **not** `CLOUDFLARE_API_TOKEN`, which deploys production Pages and is used only from workflows running under the `production` environment protection that this unattended job does not have.
 
-The workflow runs on two daily schedules, 04:20 and 06:20 UTC, and also supports `workflow_dispatch`. GitHub delays scheduled runs by up to about an hour under load (observed: 47 minutes on 2026-08-24, which made the original single 07:20 slot miss that day's digest; 53 minutes on 2026-08-26), so a single slot leaves exactly one attempt before the 08:05 UTC digest cron. The 04:20 attempt normally publishes; the 06:20 attempt retries after a failed or delayed first run and exits early — rendering and writing nothing — when the live manifest already carries today's date with data fresh enough (`asOfSec` under 6 hours) to clear the digest's own 72-hour staleness gate. Manual dispatches never take that early exit, so an operator can always supersede a bad same-day poster; selecting `accept_snapshot_transition` is reserved for a separately reviewed baseline transition and remains visible in the workflow summary.
+The workflow runs on three daily schedules, 02:20, 04:20, and 06:20 UTC, and also supports `workflow_dispatch`. GitHub delays scheduled runs by up to about an hour under load (observed: 47 minutes on 2026-08-24, which made the original single 07:20 slot miss that day's digest; 53 minutes on 2026-08-26), so a single slot leaves exactly one attempt before the 08:05 UTC digest cron. A later scheduled slot exits early — rendering and writing nothing — when the live manifest already carries today's date with data under six hours old. Manual dispatches never take that early exit, so an operator can always supersede a bad same-day poster.
 
 ## Serving
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,7 +8,7 @@ Operational and CI helper scripts live in `scripts/`, while worker-bound operati
 
 ## Safety Score Map Refresh
 
-`npm run build:safety-score-map` fetches the report cards, stablecoin supply, and Stability Index again whenever a day-over-day delta guard rejects a live read. The producer makes up to three complete fetch-and-validate attempts with backoff, logging each attempt's observed census, tier supply, and missing-logo count. A rejection that clears on a later fresh read is reported as transient recovery; three rejected attempts fail closed and still require deliberate `--accept-snapshot-transition` review for a genuine transition. Guard thresholds, including the 25% supply limit, are unchanged.
+`npm run build:safety-score-map` fetches one canonical set of report cards, stablecoin supply, and Stability Index data, then renders it. The map does not compare scores, grades, tier populations, leaders, or supply movements with an earlier run; those audits belong to the Safety Score publication pipeline. It retains only input-contract and renderability checks, so a schema-valid held or aged Safety Score publication still produces a poster while malformed data, unusable supply joins, stale PSI context, invalid geometry, missing fonts, or a wrong-size raster fail closed.
 
 `.github/workflows/safety-map-refresh.yml` schedules the refresh at 02:20, 04:20, and 06:20 UTC, plus manual dispatch. GitHub scheduled starts are best-effort and can arrive hours late, so the additional slots only improve the odds. The digest is independent of winning this race and can carry forward a recent dated map within its bounded continuity window.
 

--- a/scripts/__tests__/build-safety-score-map-clock.test.ts
+++ b/scripts/__tests__/build-safety-score-map-clock.test.ts
@@ -23,8 +23,7 @@ import {
  * production, months later. These tests pin it here instead:
  *
  *  - the structural pin below fails immediately on a second clock read;
- *  - the emitted-artifact test proves the shipped triple actually agrees, and
- *    is the only coverage of the exit-0 first-run bootstrap path.
+ *  - the emitted-artifact test proves the shipped sidecars actually agree.
  */
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -48,7 +47,7 @@ describe("clock discipline — structural pin on the generator source", () => {
 
   it("never re-reads the clock after renderedAtSec is fixed", () => {
     // Everything after this point — naming, the backwards-publish check, the
-    // render, and all three emitted files — must share the hoisted read. The
+    // render, and all emitted files — must share the hoisted read. The
     // backwards-publish comparison is the sole permitted later `Date.now()`.
     const tail = source.slice(source.indexOf("const renderedAtSec ="));
     const laterClockReads = tail.match(/Date\.now\(\)/g) ?? [];
@@ -60,8 +59,8 @@ describe("clock discipline — structural pin on the generator source", () => {
   it("stamps every emitted artifact with the same runDate value", () => {
     const tail = source.slice(source.indexOf("const renderedAtSec ="));
     const dateFields = tail.match(/\bdate: [A-Za-z.]+/g) ?? [];
-    // alt.json, snapshot.json, manifest.json, and snapshot.mapSummary — one each, all runDate.
-    expect(dateFields).toEqual(["date: runDate", "date: runDate", "date: runDate", "date: runDate"]);
+    // manifest.mapSummary, alt.json, and manifest.json — one each, all runDate.
+    expect(dateFields).toEqual(["date: runDate", "date: runDate", "date: runDate"]);
     expect(tail).toMatch(/renderedAt: new Date\(renderedAtSec \* 1000\)\.toISOString\(\)/);
   });
 });
@@ -177,7 +176,7 @@ describe.skipIf(!firefoxInstalled)("clock discipline — emitted artifacts (full
   });
 
   it(
-    "renders a first run with no previous snapshot (exit 0) and stamps date, renderedAtSec and asOfSec consistently",
+    "renders canonical data and stamps date, renderedAtSec and asOfSec consistently",
     { timeout: 120_000 },
     async () => {
       const outDir = mkdtempSync(join(tmpdir(), "pharos-safety-map-render-"));
@@ -192,40 +191,32 @@ describe.skipIf(!firefoxInstalled)("clock discipline — emitted artifacts (full
       child.stderr.on("data", (chunk) => (stderr += String(chunk)));
       const status = await new Promise<number | null>((done) => child.on("close", done));
 
-      // The bootstrap path: a missing delta baseline warns, it does not fail.
-      expect(`${stdout}${stderr}`).toMatch(/No --previous-snapshot supplied — day-over-day delta guard skipped/);
       expect(status, `${stdout}\n${stderr}`).toBe(0);
       expect(existsSync(pngPath)).toBe(true);
 
       const read = (suffix: string) => JSON.parse(readFileSync(join(outDir, `map${suffix}`), "utf8"));
-      const snapshot = read(".snapshot.json");
       const manifest = read(".manifest.json");
       const alt = read(".alt.json");
       const svg = readFileSync(join(outDir, "map.svg"), "utf8");
 
       // Rule 7: `date` is the UTC date of `renderedAtSec`, in every artifact.
-      expect(snapshot.date).toBe(utcDate(snapshot.renderedAtSec));
       expect(manifest.date).toBe(utcDate(manifest.renderedAtSec));
-      expect(alt.date).toBe(snapshot.date);
-      expect(manifest.renderedAtSec).toBe(snapshot.renderedAtSec);
+      expect(alt.date).toBe(manifest.date);
       expect(manifest.renderedAt).toBe(new Date(manifest.renderedAtSec * 1000).toISOString());
 
       // The capture clock is carried through untouched and is a *different* UTC
       // day, so a run that confused the two would be caught here.
-      expect(snapshot.asOfSec).toBe(capturedAtSec);
       expect(manifest.asOfSec).toBe(capturedAtSec);
       expect(alt.asOfSec).toBe(capturedAtSec);
-      expect(utcDate(capturedAtSec)).not.toBe(snapshot.date);
+      expect(utcDate(capturedAtSec)).not.toBe(manifest.date);
       expect(alt.altText).toContain(`data as of ${utcDate(capturedAtSec)}`);
       expect(alt.psi).toEqual({ score: 93.8, band: "BEDROCK", basis: "24H AVG", computedAt: expect.any(Number) });
       expect(alt.altText).toContain("PSI 93.8 · BEDROCK · 24H AVG at render time");
 
-      // The census the next run's delta guard will read back.
-      expect(snapshot.counts.graded).toBe(cards.length);
-      expect(snapshot.coins).toHaveLength(cards.length);
-      expect(snapshot.publicationStatus).toBe("current");
-      expect(snapshot.mapSummary.floorMcapByTier.a).toBeGreaterThan(snapshot.mapSummary.floorMcapByTier.other);
-      expect(snapshot.mapSummary.tiers).toHaveLength(5);
+      expect(manifest.counts.graded).toBe(cards.length);
+      expect(manifest.publicationStatus).toBe("current");
+      expect(manifest.mapSummary.floorMcapByTier.a).toBeGreaterThan(manifest.mapSummary.floorMcapByTier.other);
+      expect(manifest.mapSummary.tiers).toHaveLength(5);
       expect(alt.altText).toContain("five discrete grade bands: A at the centre, then B, C, D, and F outward");
       expect(alt.altText).toContain("orbit = grade band, not a continuous score");
       expect(alt.altText).toContain("assets below those thresholds share a fixed presence marker");

--- a/scripts/__tests__/build-safety-score-map-guards.test.ts
+++ b/scripts/__tests__/build-safety-score-map-guards.test.ts
@@ -20,7 +20,7 @@ import {
  *
  * The generator runs unattended every day and publishes to a public URL, so the
  * failure that matters is not a crash — it is a successful exit that ships a
- * blank or stale poster. Every guard below is asserted through the real CLI
+ * blank or malformed poster. Every guard below is asserted through the real CLI
  * against a fixture API, because the guards live inside `main()` and are not
  * individually exported. Each fixture is shaped to stop the run *before* the
  * headless-Firefox render, so the suite needs no browser and no credentials.
@@ -186,7 +186,7 @@ interface RunResult {
  *
  * `stopBeforeRender` pre-writes a future-dated manifest at the output path. The
  * backwards-publish guard (§11.2b rule 5) then aborts the run *after* fetch,
- * freshness, join, delta, layout and the composition linter have all passed but
+ * input validation, join, layout and the composition linter have all passed but
  * *before* Firefox launches — so a test can assert "the run got this far"
  * without paying for a real render.
  */
@@ -227,9 +227,6 @@ async function runGenerator(
       ...process.env,
       PHAROS_API_BASE: baseUrl,
       PHAROS_API_KEY: "fixture-key",
-      // Persistent-rejection cases re-fetch three times; the real backoff is
-      // dead wait here and pushed these past the suite timeout under load.
-      PHAROS_DELTA_GUARD_BACKOFF_SCALE: "0",
     },
   });
   let stdout = "";
@@ -243,39 +240,18 @@ async function runGenerator(
 /** Marker proving the run reached the pre-render stop, i.e. every guard passed. */
 const REACHED_RENDER_GATE = /rendered in the future/;
 
-describe("safety-score map — freshness guard (§11.2b rule 1)", () => {
-  it("refuses to render a report-card capture older than 48h", async () => {
-    const run = await runGenerator({ ...universe(), asOfSec: Math.floor(Date.now() / 1000) - 49 * HOUR });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Report-card capture is 49\.\dh old \(must be under 48h\) — refusing to render stale scores/);
-    expect(existsSync(run.pngPath)).toBe(false);
-  });
-
-  it("does not trip on a capture just inside the 48h ceiling", async () => {
+describe("safety-score map — canonical publication provenance", () => {
+  it("renders an aged report-card capture with its source timestamp intact", async () => {
     const run = await runGenerator(
-      { ...universe(), asOfSec: Math.floor(Date.now() / 1000) - 47 * HOUR },
+      { ...universe(), asOfSec: Math.floor(Date.now() / 1000) - 49 * HOUR },
       { stopBeforeRender: true },
     );
-    expect(run.stderr).not.toMatch(/refusing to render stale scores/);
     expect(run.stderr).toMatch(REACHED_RENDER_GATE);
   });
 
-  it("refuses a future-dated capture", async () => {
-    const run = await runGenerator({ ...universe(), asOfSec: Math.floor(Date.now() / 1000) + HOUR });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/future-dated capture/);
-  });
-
-  it("refuses a capture at the 48h boundary", async () => {
-    const run = await runGenerator({ ...universe(), asOfSec: Math.floor(Date.now() / 1000) - 48 * HOUR });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/must be under 48h/);
-  });
-
-  it("refuses a held publication even when the capture is fresh", async () => {
-    const run = await runGenerator({ ...universe() }, { publicationStatus: "held" });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/publication status is "held".*non-current/);
+  it("renders a held canonical publication instead of re-auditing upstream health", async () => {
+    const run = await runGenerator({ ...universe() }, { publicationStatus: "held", stopBeforeRender: true });
+    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
   });
 
   it("rejects a non-numeric capture clock rather than rendering an epoch-stamped poster", async () => {
@@ -435,350 +411,25 @@ describe("safety-score map — grade-letter integrity", () => {
   });
 });
 
-describe("safety-score map — day-over-day delta guard (§11.2b rule 2)", () => {
-  function snapshot(dir: string, body: unknown): string {
-    const path = join(dir, "previous.snapshot.json");
-    writeFileSync(path, typeof body === "string" ? body : JSON.stringify(body));
-    return path;
-  }
-
-  function validSnapshot(fixture: { cards: Card[]; assets: Asset[] }) {
-    const byAsset = new Map(fixture.assets.map((asset) => [asset.id, asset]));
-    const rated = fixture.cards.filter((card) => card.grade !== "NR");
-    const tierOrder = ["A", "B", "C", "D", "F"] as const;
-    const byTier = Object.fromEntries(tierOrder.map((tier) => [tier, rated.filter((card) => card.grade.charAt(0) === tier)]));
-    const mcapOf = (id: string) => {
-      const value = byAsset.get(id)?.circulating?.peggedUSD ?? 0;
-      return Math.max(0, value);
-    };
-    const totalMcap = rated.reduce((sum, card) => sum + mcapOf(card.id), 0);
-    return {
-      publicationStatus: "current",
-      counts: {
-        graded: rated.length,
-        notRated: fixture.cards.length - rated.length,
-        unjoined: rated.filter((card) => mcapOf(card.id) <= 0).length,
-        missingLogos: rated.length,
-        byTier: Object.fromEntries(tierOrder.map((tier) => [tier, byTier[tier].length])),
+describe("safety-score map — availability-first rendering", () => {
+  it("fetches one canonical input set and has no historical movement gate", async () => {
+    const fixture = universe({ count: 20 });
+    const payload = makeSafetyMapStablecoinsPayload(fixture.assets);
+    let stablecoinReads = 0;
+    const run = await runGenerator(fixture, {
+      stopBeforeRender: true,
+      stablecoinsPayload: () => {
+        stablecoinReads += 1;
+        return payload;
       },
-      mapSummary: {
-        date: "2026-08-24",
-        asOfSec: Math.floor(Date.now() / 1000) - HOUR,
-        methodologyVersion: "9.19",
-        gradedCount: rated.length,
-        notRatedCount: fixture.cards.length - rated.length,
-        totalMcapUsd: totalMcap,
-        floorMcapByTier: { a: 1, other: 1 },
-        tiers: tierOrder.map((tier) => {
-          const cards = byTier[tier];
-          const tierMcap = cards.reduce((sum, card) => sum + mcapOf(card.id), 0);
-          return {
-            tier,
-            range: "0-100",
-            count: cards.length,
-            mcapUsd: tierMcap,
-            sharePct: totalMcap > 0 ? (tierMcap / totalMcap) * 100 : 0,
-            leaders: [...cards]
-              .sort((a, b) => mcapOf(b.id) - mcapOf(a.id))
-              .slice(0, 3)
-              .map((card) => ({ symbol: byAsset.get(card.id)?.symbol ?? card.id, score: card.score as number, mcapUsd: mcapOf(card.id) })),
-          };
-        }),
-      },
-      coins: rated.map((card) => ({
-        id: card.id,
-        symbol: byAsset.get(card.id)?.symbol ?? card.id,
-        score: card.score as number,
-        grade: card.grade,
-        mcap: mcapOf(card.id),
-      })),
-    };
-  }
-
-  const scratch = scratchDir("pharos-safety-map-snapshots-");
-
-  it("refuses to publish a census that shrank more than 2% overnight", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 100 })));
-    const run = await runGenerator(universe({ count: 20 }), { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Graded count fell from 100 to 20 \(>2%\) since the previous snapshot/);
-    expect(run.stderr).toMatch(/refusing to publish a shrunken census/);
-  });
-
-  it("refuses when the not-rated count moves more than 5 overnight", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 20 })));
-    const run = await runGenerator(universe({ count: 20, notRated: 6 }), { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Not-rated count moved from 0 to 6 \(>5\) since the previous snapshot/);
-    expect(run.stderr).toMatch(/scoring producer looks half-broken/);
-  });
-
-  it("falls back to the previous snapshot's coin array when counts are absent", async () => {
-    const path = snapshot(scratch, { coins: Array.from({ length: 100 }, (_, i) => ({ id: `c${i}` })) });
-    const run = await runGenerator(universe({ count: 20 }), { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/is malformed/);
-  });
-
-  it("passes a census that held steady, and says so", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 20, notRated: 2 })));
-    const run = await runGenerator(universe({ count: 20, notRated: 2 }), {
-      args: ["--previous-snapshot", path],
-      stopBeforeRender: true,
     });
-    expect(run.stdout).toMatch(/Delta guard OK vs previous snapshot \(graded 20 -> 20, not rated 2 -> 2\)/);
+
+    expect(stablecoinReads).toBe(1);
+    expect(run.stdout).toMatch(/Fetching canonical data/);
+    expect(run.stdout).toMatch(/Render input graded=20/);
     expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("tolerates a drop inside the 2% band and a not-rated move of exactly 5", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 20 })));
-    const run = await runGenerator(universe({ count: 20, notRated: 5 }), {
-      args: ["--previous-snapshot", path],
-      stopBeforeRender: true,
-    });
-    expect(run.stderr).not.toMatch(/Not-rated count moved/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("re-fetches live data when a transient supply delta rejection recovers", async () => {
-    const prior = universe({ count: 20 });
-    const badAssets = prior.assets.map((asset) => asset.id === "coin-11"
-      ? { ...asset, circulating: { peggedUSD: (asset.circulating?.peggedUSD ?? 0) * 5 } }
-      : asset);
-    const badPayload = makeSafetyMapStablecoinsPayload(badAssets);
-    const goodPayload = makeSafetyMapStablecoinsPayload(prior.assets);
-    let reads = 0;
-    const path = snapshot(scratch, validSnapshot(prior));
-    const run = await runGenerator(prior, {
-      args: ["--previous-snapshot", path],
-      stopBeforeRender: true,
-      stablecoinsPayload: () => reads++ === 0 ? badPayload : goodPayload,
-    });
-    // stopBeforeRender deliberately trips the future-manifest guard after all
-    // fetch, retry, and validation work has passed; reaching that marker is
-    // the success signal for this no-browser fixture.
-    expect(reads).toBeGreaterThanOrEqual(2);
-    expect(run.stderr).toMatch(/Validation attempt 1\/3 rejected by delta guard/);
-    expect(run.stdout).toMatch(/Delta guard transient rejection recovered on attempt 2/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-    expect(run.stderr).not.toMatch(/Persistent delta guard rejection/);
-  });
-
-  it("fails closed after a persistent delta rejection on all three fresh attempts", async () => {
-    const prior = universe({ count: 20 });
-    const badAssets = prior.assets.map((asset) => asset.id === "coin-11"
-      ? { ...asset, circulating: { peggedUSD: (asset.circulating?.peggedUSD ?? 0) * 5 } }
-      : asset);
-    const badPayload = makeSafetyMapStablecoinsPayload(badAssets);
-    const path = snapshot(scratch, validSnapshot(prior));
-    const run = await runGenerator(prior, {
-      args: ["--previous-snapshot", path],
-      stablecoinsPayload: () => badPayload,
-    });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Validation attempt 1\/3 rejected by delta guard/);
-    expect(run.stderr).toMatch(/Validation attempt 2\/3 rejected by delta guard/);
-    expect(run.stderr).toMatch(/Validation attempt 3\/3 rejected by delta guard/);
-    expect(run.stderr).toMatch(/Persistent delta guard rejection after 3 attempts/);
-  });
-
-  it("keeps the 25% supply threshold unchanged", async () => {
-    const prior = universe({ count: 20 });
-    const withinThreshold = prior.assets.map((asset) => asset.id === "coin-11"
-      ? { ...asset, circulating: { peggedUSD: (asset.circulating?.peggedUSD ?? 0) * 1.24 } }
-      : asset);
-    const path = snapshot(scratch, validSnapshot(prior));
-    const run = await runGenerator({ cards: prior.cards, assets: withinThreshold }, {
-      args: ["--previous-snapshot", path],
-      stopBeforeRender: true,
-    });
-    expect(run.stderr).not.toMatch(/supply moved.*>25%/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("rejects a malformed baseline instead of treating it as a first run", async () => {
-    const path = snapshot(scratch, { counts: { graded: 0, notRated: 0 } });
-    const run = await runGenerator(universe({ count: 20 }), { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/is malformed/);
-  });
-
-  it("accepts reviewed deltas only after validating the full previous-snapshot contract", async () => {
-    const prior = universe({ count: 20 });
-    let moved = 0;
-    const nextCards = prior.cards.map((card) => {
-      if (moved >= 3 || !card.grade.startsWith("B")) return card;
-      moved += 1;
-      return { ...card, grade: "C+", score: 62 };
-    });
-    const path = snapshot(scratch, validSnapshot(prior));
-    const run = await runGenerator({ cards: nextCards, assets: prior.assets }, {
-      args: ["--previous-snapshot", path, "--accept-snapshot-transition"],
-      stopBeforeRender: true,
-    });
-
-    expect(run.stderr).toMatch(/Operator accepted the validated previous snapshot transition/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("rejects a malformed baseline even when snapshot-transition acceptance is requested", async () => {
-    const path = snapshot(scratch, { publicationStatus: "current" });
-    const run = await runGenerator(universe({ count: 20 }), {
-      args: ["--previous-snapshot", path, "--accept-snapshot-transition"],
-    });
-
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/is malformed/);
-  });
-
-  it("rejects a large per-tier reclassification even when the total census is unchanged", async () => {
-    const prior = universe({ count: 20 });
-    const nextCards = prior.cards.map((card) => card.grade.startsWith("A") ? { ...card, grade: "B+", score: 77 } : card);
-    const path = snapshot(scratch, validSnapshot(prior));
-    const run = await runGenerator({ cards: nextCards, assets: prior.assets }, { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Tier A count moved/);
-  });
-
-  it("tolerates a near-tie leader swap when the prior census explains the new leader", async () => {
-    const prior = universe({ count: 20 });
-    const body = validSnapshot(prior);
-    // Yesterday C1 narrowly led tier A over C0; today the live data has C0
-    // ahead again. The prior census knows C0 at its current supply, so this is
-    // ordinary market movement, not a broken join.
-    const leaders = body.mapSummary.tiers.find((tier) => tier.tier === "A")!.leaders;
-    [leaders[0], leaders[1]] = [leaders[1], leaders[0]];
-    const path = snapshot(scratch, body);
-    const run = await runGenerator(prior, { args: ["--previous-snapshot", path], stopBeforeRender: true });
-    expect(run.stderr).not.toMatch(/leader/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("tolerates a new leader from outside the recorded top-3 when the census explains it", async () => {
-    const prior = universe({ count: 20 });
-    const body = validSnapshot(prior);
-    // Yesterday's recorded top-3 omitted C0 entirely (it sat 4th); today it
-    // leads tier A. The prior census still carries coin-00 at its current
-    // supply, so the crossover is explained without any recorded-top-3 seat.
-    const leaders = body.mapSummary.tiers.find((tier) => tier.tier === "A")!.leaders;
-    leaders.splice(0, leaders.length, ...leaders.filter((leader) => leader.symbol !== "C0"));
-    const path = snapshot(scratch, body);
-    const run = await runGenerator(prior, { args: ["--previous-snapshot", path], stopBeforeRender: true });
-    expect(run.stderr).not.toMatch(/leader/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("refuses a leader the previous census never saw", async () => {
-    const prior = universe({ count: 20 });
-    const body = validSnapshot(prior);
-    // Rewrite yesterday's identity for coin-00 so today's tier A leader C0 is
-    // a coin the previous census has no record of.
-    body.mapSummary.tiers.find((tier) => tier.tier === "A")!.leaders[0].symbol = "CX";
-    const row = body.coins.find((coin) => coin.id === "coin-00")!;
-    row.id = "coin-xx";
-    row.symbol = "CX";
-    const path = snapshot(scratch, body);
-    const run = await runGenerator(prior, { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Tier A leader changed to C0, absent from the previous census — refusing an unexplained leader shift/);
-  });
-
-  it("refuses a leader swap when the new leader's own supply moved more than 25%", async () => {
-    const prior = universe({ count: 20 });
-    const body = validSnapshot(prior);
-    const leaders = body.mapSummary.tiers.find((tier) => tier.tier === "A")!.leaders;
-    [leaders[0], leaders[1]] = [leaders[1], leaders[0]];
-    // The prior census has the new leader at double its current supply, so the
-    // swap is no longer explained by bounded day-over-day movement.
-    body.coins.find((coin) => coin.id === "coin-00")!.mcap *= 2;
-    const path = snapshot(scratch, body);
-    const run = await runGenerator(prior, { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Tier A leader C0 supply moved from \d+ to \d+ \(>25%\) since the previous snapshot — refusing an unexplained leader shift/);
-  });
-
-  it("tolerates a single immaterial join flip and draws the coin at the size floor", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 20 })));
-    const run = await runGenerator(universe({ count: 20, unjoined: 1 }), {
-      args: ["--previous-snapshot", path],
-      stopBeforeRender: true,
-    });
-    expect(run.stderr).toMatch(/Supply join identity changed for 1 coin\(s\) since the previous snapshot \(coin-19; \$[\d,]+ affected\) — within tolerance/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("refuses when more than three coins flip join identity overnight", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 100 })));
-    const run = await runGenerator(universe({ count: 100, unjoined: 4 }), { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Supply join identity changed for 4 coin\(s\)/);
-    expect(run.stderr).toMatch(/beyond the tolerance .* refusing to publish an ambiguous census/);
-  });
-
-  it("refuses a single join flip that carries material supply", async () => {
-    const prior = universe({ count: 20 });
-    const path = snapshot(scratch, validSnapshot(prior));
-    const current = {
-      cards: prior.cards,
-      assets: prior.assets.map((row) => (row.id === "coin-06" ? { ...row, circulating: { peggedUSD: 0 } } : row)),
-    };
-    const run = await runGenerator(current, { args: ["--previous-snapshot", path] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/Supply join identity changed for 1 coin\(s\) since the previous snapshot \(coin-06;/);
-    expect(run.stderr).toMatch(/beyond the tolerance/);
-  });
-
-  it("does not treat a census addition as a join flip", async () => {
-    const path = snapshot(scratch, validSnapshot(universe({ count: 20 })));
-    // The all-logoless fixture universe makes the addition trip the separate
-    // missing-logo guard (20 -> 21), which runs after the delta guard — so the
-    // join-identity check demonstrably let the addition through.
-    const run = await runGenerator(universe({ count: 21 }), { args: ["--previous-snapshot", path] });
-    expect(run.stderr).not.toMatch(/Supply join identity changed/);
-    expect(run.stdout).toMatch(/Delta guard OK vs previous snapshot \(graded 20 -> 21/);
-    expect(run.stderr).toMatch(/Missing-logo count moved from 20 to 21/);
   });
 });
-
-describe("safety-score map — delta guard skips are never fatal (bootstrap path)", () => {
-  const scratch = scratchDir("pharos-safety-map-skips-");
-
-  // A first run has nothing to compare against and must still boot. Each case
-  // proves the guard warned and execution continued past it; the run is then
-  // stopped at the pre-render gate rather than paying for a real render.
-  const cases: Array<[string, string[], RegExp]> = [
-    ["no --previous-snapshot at all", [], /No --previous-snapshot supplied — day-over-day delta guard skipped/],
-    [
-      "a --previous-snapshot path that does not exist",
-      ["--previous-snapshot", join(scratch, "absent.json")],
-      /Could not read --previous-snapshot .*absent\.json .* — delta guard skipped/,
-    ],
-  ];
-
-  it.each(cases)("skips with a warning: %s", async (_label, args, expected) => {
-    const run = await runGenerator(universe(), { args, stopBeforeRender: true });
-    expect(`${run.stdout}${run.stderr}`).toMatch(expected);
-    expect(run.stderr).not.toMatch(/Graded count fell|Not-rated count moved/);
-    expect(run.stderr).toMatch(REACHED_RENDER_GATE);
-  });
-
-  it("rejects an unparseable previous snapshot", async () => {
-    const path = join(scratch, "corrupt.json");
-    writeFileSync(path, "{ not json");
-    const run = await runGenerator(universe(), { args: ["--previous-snapshot", path], stopBeforeRender: true });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/is malformed/);
-  });
-
-  it("rejects a previous snapshot with no graded count", async () => {
-    const path = join(scratch, "countless.json");
-    writeFileSync(path, JSON.stringify({ edition: "daily", date: "2026-08-20" }));
-    const run = await runGenerator(universe(), { args: ["--previous-snapshot", path], stopBeforeRender: true });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/is malformed/);
-  });
-});
-
 describe("safety-score map — backwards-publish guard (§11.2b rule 5)", () => {
   it("refuses to overwrite a manifest rendered in the future", async () => {
     const run = await runGenerator(universe(), { stopBeforeRender: true });
@@ -801,9 +452,4 @@ describe("safety-score map — CLI contract", () => {
     expect(run.stderr).toMatch(/--issue must be a positive integer/);
   });
 
-  it("requires a previous snapshot when accepting a snapshot transition", async () => {
-    const run = await runGenerator(universe(), { args: ["--accept-snapshot-transition"] });
-    expect(run.status).toBe(1);
-    expect(run.stderr).toMatch(/--accept-snapshot-transition requires --previous-snapshot/);
-  });
 });

--- a/scripts/__tests__/publish-safety-score-map.test.ts
+++ b/scripts/__tests__/publish-safety-score-map.test.ts
@@ -36,41 +36,6 @@ function createIo(): PublicationIo & { output: string[]; text: string[] } {
   };
 }
 
-function validPreviousSnapshot(): Record<string, unknown> {
-  const tiers = ["A", "B", "C", "D", "F"].map((tier) => ({
-    tier,
-    range: "0-100",
-    count: tier === "A" ? 1 : 0,
-    mcapUsd: tier === "A" ? 100 : 0,
-    sharePct: tier === "A" ? 100 : 0,
-    leaders: tier === "A"
-      ? [{ symbol: "USD", score: 90, mcapUsd: 100 }]
-      : [],
-  }));
-  return {
-    date: "2026-07-26",
-    publicationStatus: "current",
-    counts: {
-      graded: 1,
-      notRated: 0,
-      unjoined: 0,
-      missingLogos: 0,
-      byTier: { A: 1, B: 0, C: 0, D: 0, F: 0 },
-    },
-    mapSummary: {
-      date: "2026-07-26",
-      asOfSec: Date.UTC(2026, 6, 26, 8, 0, 0) / 1000,
-      methodologyVersion: "9.43",
-      gradedCount: 1,
-      notRatedCount: 0,
-      totalMcapUsd: 100,
-      floorMcapByTier: { a: 1, other: 1 },
-      tiers,
-    },
-    coins: [{ id: "usd", symbol: "USD", score: 90, grade: "A+", mcap: 100 }],
-  };
-}
-
 class MockKvAdapter implements SafetyMapKvAdapter {
   readonly puts: Array<{ key: string; path: string }> = [];
   listings = new Map<string, string[]>();
@@ -96,11 +61,9 @@ class MockKvAdapter implements SafetyMapKvAdapter {
 
 function writeRenderedState(directory: string, overrides: Partial<SafetyMapPublishState> = {}): string {
   const pngPath = join(directory, "latest.png");
-  const snapshotPath = join(directory, "latest.snapshot.json");
   const altPath = join(directory, "latest.alt.json");
   const manifestPath = join(directory, "kv-manifest.json");
   writeFileSync(pngPath, "png bytes");
-  writeFileSync(snapshotPath, "snapshot bytes");
   writeFileSync(altPath, "alt bytes");
   writeFileSync(manifestPath, "manifest bytes");
   const state: SafetyMapPublishState = {
@@ -109,7 +72,6 @@ function writeRenderedState(directory: string, overrides: Partial<SafetyMapPubli
     plannedAtSec: 1_785_283_200,
     alreadyPublished: false,
     hadManifest: false,
-    deltaGuard: "ran",
     manifestPath,
     manifest: {
       date: "2026-07-27",
@@ -117,8 +79,11 @@ function writeRenderedState(directory: string, overrides: Partial<SafetyMapPubli
       renderedAtSec: 1_785_283_200,
       edition: "daily",
       methodologyVersion: "9.44",
+      publicationStatus: "held",
+      updatedAt: "2026-07-27T07:59:00.000Z",
+      publicationHealth: { status: "held" },
       counts: { graded: 42, notRated: 3 },
-      bytes: { png: 9, alt: 9, snapshot: 14 },
+      bytes: { png: 9, alt: 9 },
     },
     ...overrides,
   };
@@ -137,8 +102,6 @@ describe("Safety Map publication CLI", () => {
 
     expect(result.phase).toBe("published");
     expect(adapter.puts.map(({ key }) => key)).toEqual([
-      "safety-map:snapshot:2026-07-27",
-      "safety-map:snapshot:latest",
       "safety-map:alt:latest",
       "safety-map:2026-07-27.png",
       "safety-map:latest.png",
@@ -176,31 +139,17 @@ describe("Safety Map publication CLI", () => {
     expect(existsSync(dryRunStatePath)).toBe(false);
   });
 
-  it("accepts an audited snapshot transition only on a manual run", async () => {
+  it("renders directly from canonical inputs and builds the KV manifest", async () => {
     const directory = temporaryDirectory();
     const statePath = join(directory, "publish-state.json");
     const adapter = new MockKvAdapter();
     const nowSec = Date.UTC(2026, 6, 27, 8, 0, 0) / 1000;
-    adapter.listings.set("safety-map:snapshot:latest", ["safety-map:snapshot:latest"]);
-    adapter.values.set("safety-map:snapshot:latest", Buffer.from(JSON.stringify(validPreviousSnapshot())));
-
-    await expect(planSafetyMapPublication({
-      acceptSnapshotTransition: true,
-      adapter,
-      eventName: "schedule",
-      nowSec,
-      statePath,
-    })).rejects.toThrow("restricted to workflow_dispatch");
-
-    const planned = await planSafetyMapPublication({
-      acceptSnapshotTransition: true,
+    await planSafetyMapPublication({
       adapter,
       eventName: "workflow_dispatch",
       nowSec,
       statePath,
     });
-    expect(planned.acceptedSnapshotTransition).toBe(true);
-    expect(planned.previousSnapshotPath).toBe(join(directory, "previous-snapshot.json"));
 
     let renderCommand = "";
     const rendered = await renderSafetyMapPublication({
@@ -208,12 +157,15 @@ describe("Safety Map publication CLI", () => {
         renderCommand = command;
         writeFileSync(join(directory, "latest.png"), "png bytes");
         writeFileSync(join(directory, "latest.alt.json"), "alt bytes");
-        writeFileSync(join(directory, "latest.snapshot.json"), JSON.stringify({
+        writeFileSync(join(directory, "latest.manifest.json"), JSON.stringify({
           date: "2026-07-27",
           asOfSec: nowSec - 60,
           renderedAtSec: nowSec,
           edition: "daily",
           methodologyVersion: "9.44",
+          publicationStatus: "held",
+          updatedAt: "2026-07-27T07:59:00.000Z",
+          publicationHealth: { status: "held" },
           counts: { graded: 43, notRated: 2 },
         }));
         return 0;
@@ -222,9 +174,8 @@ describe("Safety Map publication CLI", () => {
       statePath,
     });
 
-    expect(rendered.deltaGuard).toBe("accepted");
-    expect(renderCommand).toContain(`--previous-snapshot '${join(directory, "previous-snapshot.json")}'`);
-    expect(renderCommand).toContain("--accept-snapshot-transition");
+    expect(rendered.manifest?.publicationStatus).toBe("held");
+    expect(renderCommand).toBe(`npm run build:safety-score-map -- --out '${join(directory, "latest.png")}'`);
   });
 
   it("refuses to publish behind the live manifest before the first write", async () => {
@@ -249,8 +200,6 @@ describe("Safety Map publication CLI", () => {
     await expect(publishSafetyMapPublication({ adapter, outDir: directory, statePath }))
       .rejects.toThrow("failed SHA-256 readback comparison");
     expect(adapter.puts.map(({ key }) => key)).toEqual([
-      "safety-map:snapshot:2026-07-27",
-      "safety-map:snapshot:latest",
       "safety-map:alt:latest",
       "safety-map:2026-07-27.png",
     ]);
@@ -265,17 +214,8 @@ describe("Safety Map publication CLI", () => {
     const summary = buildSafetyMapSummary(state, "success");
 
     expect(summary).toContain("## Safety Map refresh — success");
-    expect(summary).toContain("| Day-over-day delta guard | ran |");
+    expect(summary).toContain("| Safety Score source | `held` |");
     expect(summary).toContain("`safety-map:2026-07-27.png` — the URL the digest embeds");
     expect(summary.trimEnd().endsWith("`safety-map:latest.json` — manifest, written last")).toBe(true);
-  });
-
-  it("labels transient recovery and persistent delta rejection in the summary", () => {
-    const directory = temporaryDirectory();
-    const recovered = JSON.parse(readFileSync(writeRenderedState(directory, { deltaGuard: "recovered" }), "utf8")) as SafetyMapPublishState;
-    expect(buildSafetyMapSummary(recovered, "success")).toContain("Transient rejection recovered");
-
-    const persistent = JSON.parse(readFileSync(writeRenderedState(directory, { deltaGuard: "persistent", phase: "planned" }), "utf8")) as SafetyMapPublishState;
-    expect(buildSafetyMapSummary(persistent, "failure")).toContain("Persistent delta rejection");
   });
 });

--- a/scripts/maintenance/build-safety-score-map.ts
+++ b/scripts/maintenance/build-safety-score-map.ts
@@ -30,21 +30,11 @@
  *   - $PHAROS_API_BASE: optional API origin override
  *   - live PSI: the current display level and condition band shown beneath the
  *     map title, fetched during the render alongside report cards and supply
- *   - --previous-snapshot <path>: the prior run's .snapshot.json, which arms
- *     the day-over-day delta guard. Optional; absent or unreadable skips that
- *     guard with a warning so a first run can bootstrap. Freshness, finite
- *     geometry, and join coverage are asserted unconditionally.
- *   - --accept-snapshot-transition: with a readable previous snapshot, validate
- *     its full contract but accept its day-over-day comparison as reviewed.
  *
  * Outputs (alongside the PNG, sharing its basename):
  *   - .svg / .html   the rendered scene and its screenshot host
  *   - .alt.json      alt text plus the per-tier table, same numbers as the pixels
- *   - .snapshot.json header {edition, date, publicationStatus, asOfSec,
- *                    renderedAtSec, methodologyVersion, counts, mapSummary}
- *                    plus {id, symbol, score, grade, mcap} per graded coin
- *                    (movers baseline, and the next run's delta-guard input)
- *   - .manifest.json {date, asOfSec, renderedAtSec, counts, bytes}
+ *   - .manifest.json publication provenance, counts, and the public map summary
  */
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -102,42 +92,9 @@ const BODY_TOP = HEADER_RULE_Y + HEADER_BODY_GAP;
 const GALAXY_CX = 800;
 const GALAXY_CY = 482;
 
-// Data freshness ceiling for an unattended render: a stalled report-card
-// producer must fail the job, not publish week-old scores under today's date.
-const MAX_DATA_AGE_SEC = 48 * 3600;
 // Below this share of graded cards joining a list row with real supply, the
 // map is drawing floors instead of data.
 const MIN_JOIN_COVERAGE = 0.95;
-const MAX_DELTA_GUARD_ATTEMPTS = 3;
-// Spacing between fresh re-fetches after a delta-guard rejection. A transient
-// upstream read should not cost the day's poster, but the wait is dead time in
-// tests that deliberately exercise a persistent rejection, so the guard suite
-// collapses it. Production never sets this.
-const DELTA_GUARD_BACKOFF_SCALE = Number(process.env.PHAROS_DELTA_GUARD_BACKOFF_SCALE ?? "1");
-const DELTA_GUARD_BACKOFF_MS = [500, 1500].map(
-  (ms) => Math.max(0, Math.round(ms * (Number.isFinite(DELTA_GUARD_BACKOFF_SCALE) ? DELTA_GUARD_BACKOFF_SCALE : 1))),
-) as readonly number[];
-
-class DeltaGuardRejection extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DeltaGuardRejection";
-  }
-}
-
-interface DeltaGuardRetryStatus {
-  attempts: number;
-  recovered: boolean;
-  persistent: boolean;
-  rejections: string[];
-  observed: Array<{
-    attempt: number;
-    graded: number;
-    notRated: number;
-    missingLogos: number;
-    tiers: Record<Tier, { count: number; mcap: number }>;
-  }>;
-}
 
 // Palette: a midnight editorial shell lets the classification colors read as
 // orbital signals instead of spreadsheet rules.
@@ -263,27 +220,10 @@ export interface LogoRenderData {
 
 type SubgradeLane = "plus" | "base" | "minus";
 
-function writeDeltaGuardRetryStatus(status: DeltaGuardRetryStatus): void {
-  const path = process.env.SAFETY_MAP_RETRY_STATUS_PATH?.trim();
-  if (!path) return;
-  try {
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, `${JSON.stringify(status, null, 2)}\n`);
-  } catch (error) {
-    console.warn(`[safety-score-map] Could not write retry status at ${path}: ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
-}
-
 function parseCliArgs(argv: readonly string[]): {
   out: string | null;
   edition: Edition;
   issue: number | null;
-  previousSnapshot: string | null;
-  acceptSnapshotTransition: boolean;
 } {
   const { values } = parseArgs({
     args: [...argv],
@@ -291,8 +231,6 @@ function parseCliArgs(argv: readonly string[]): {
       out: { type: "string" },
       edition: { type: "string" },
       issue: { type: "string" },
-      "previous-snapshot": { type: "string" },
-      "accept-snapshot-transition": { type: "boolean" },
     },
   });
   const edition = values.edition ?? "daily";
@@ -304,12 +242,7 @@ function parseCliArgs(argv: readonly string[]): {
     issue = Number(values.issue);
     if (!Number.isInteger(issue) || issue < 1) throw new Error(`--issue must be a positive integer (got "${values.issue}")`);
   }
-  const previousSnapshot = values["previous-snapshot"] ?? null;
-  const acceptSnapshotTransition = values["accept-snapshot-transition"] === true;
-  if (acceptSnapshotTransition && !previousSnapshot) {
-    throw new Error("--accept-snapshot-transition requires --previous-snapshot");
-  }
-  return { out: values.out ?? null, edition, issue, previousSnapshot, acceptSnapshotTransition };
+  return { out: values.out ?? null, edition, issue };
 }
 
 function loadApiKey(): string {
@@ -1953,317 +1886,6 @@ function buildTierTable(tiers: readonly TierSummary[]): string {
 
 // --- Main -----------------------------------------------------------------
 
-// §11.2b rule 2: a half-broken producer shows up as a census that moves too
-// far overnight, not as a crash. Deliberately non-fatal when there is no prior
-// snapshot — a first run has nothing to compare against and must still boot.
-const MAX_GRADED_DROP = 0.02;
-const MAX_NOT_RATED_MOVE = 5;
-// A joined<->unjoined flip for a coin present on both days is usually a
-// transient upstream supply gap on one small coin, not a join-pipeline break.
-// Tolerate a few immaterial flips with a warning; refuse when flips are
-// numerous or carry real supply. Materiality is measured against the previous
-// snapshot's mapped supply.
-const MAX_JOIN_FLIPS = 3;
-const MAX_JOIN_FLIP_MCAP_SHARE = 0.001;
-
-interface SnapshotCoin {
-  id: string;
-  symbol: string;
-  score: number;
-  grade: string;
-  mcap: number;
-}
-
-interface PreviousSnapshot {
-  publicationStatus: string;
-  counts: {
-    graded: number;
-    notRated: number;
-    unjoined: number;
-    missingLogos: number;
-    byTier: Record<Tier, number>;
-  };
-  mapSummary: MapSummary;
-  coins: SnapshotCoin[];
-}
-
-interface CurrentDeltaState {
-  gradedCount: number;
-  notRatedCount: number;
-  missingLogoCount: number | null;
-  coins: readonly SnapshotCoin[];
-  tiers: readonly TierSummary[];
-}
-
-function malformedSnapshot(path: string, reason: string): never {
-  throw new Error(`--previous-snapshot ${path} is malformed: ${reason} — refusing to skip the delta guard`);
-}
-
-function nonNegativeInteger(value: unknown, label: string, path: string): number {
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) malformedSnapshot(path, `${label} must be a non-negative integer`);
-  return value as number;
-}
-
-function isSnapshotRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function parseSnapshotCoin(value: unknown, index: number, path: string): SnapshotCoin {
-  if (!isSnapshotRecord(value)) malformedSnapshot(path, `coins[${index}] is not an object`);
-  if (typeof value.id !== "string" || value.id.length === 0) malformedSnapshot(path, `coins[${index}].id is missing`);
-  if (typeof value.symbol !== "string" || value.symbol.length === 0) malformedSnapshot(path, `coins[${index}].symbol is missing`);
-  if (typeof value.grade !== "string" || !SAFETY_GRADE_VALUES.includes(value.grade as (typeof SAFETY_GRADE_VALUES)[number])) {
-    malformedSnapshot(path, `coins[${index}].grade is invalid`);
-  }
-  if (typeof value.score !== "number" || !Number.isFinite(value.score) || value.score < 0 || value.score > 100) {
-    malformedSnapshot(path, `coins[${index}].score is outside 0-100`);
-  }
-  if (scoreToGrade(value.score) !== value.grade) malformedSnapshot(path, `coins[${index}] has a score/grade disagreement`);
-  if (typeof value.mcap !== "number" || !Number.isFinite(value.mcap) || value.mcap < 0) {
-    malformedSnapshot(path, `coins[${index}].mcap must be a non-negative finite number`);
-  }
-  return {
-    id: value.id,
-    symbol: value.symbol,
-    score: value.score,
-    grade: value.grade,
-    mcap: value.mcap,
-  };
-}
-
-function parseSnapshotMapSummary(value: unknown, path: string): MapSummary {
-  if (!isSnapshotRecord(value)) malformedSnapshot(path, "mapSummary is missing");
-  if (typeof value.date !== "string" || value.date.length === 0) malformedSnapshot(path, "mapSummary.date is invalid");
-  if (typeof value.asOfSec !== "number" || !Number.isFinite(value.asOfSec) || !Number.isInteger(value.asOfSec)) malformedSnapshot(path, "mapSummary.asOfSec is invalid");
-  if (typeof value.methodologyVersion !== "string" || value.methodologyVersion.length === 0) malformedSnapshot(path, "mapSummary.methodologyVersion is invalid");
-  const gradedCount = nonNegativeInteger(value.gradedCount, "mapSummary.gradedCount", path);
-  const notRatedCount = nonNegativeInteger(value.notRatedCount, "mapSummary.notRatedCount", path);
-  if (typeof value.totalMcapUsd !== "number" || !Number.isFinite(value.totalMcapUsd) || value.totalMcapUsd < 0) malformedSnapshot(path, "mapSummary.totalMcapUsd is invalid");
-  if (!isSnapshotRecord(value.floorMcapByTier)) malformedSnapshot(path, "mapSummary.floorMcapByTier is missing");
-  if (typeof value.floorMcapByTier.a !== "number" || !Number.isFinite(value.floorMcapByTier.a) || value.floorMcapByTier.a <= 0) malformedSnapshot(path, "mapSummary.floorMcapByTier.a is invalid");
-  if (typeof value.floorMcapByTier.other !== "number" || !Number.isFinite(value.floorMcapByTier.other) || value.floorMcapByTier.other <= 0) malformedSnapshot(path, "mapSummary.floorMcapByTier.other is invalid");
-  if (!Array.isArray(value.tiers) || value.tiers.length !== TIER_ORDER.length) malformedSnapshot(path, "mapSummary.tiers must contain every grade band");
-
-  const seenTiers = new Set<string>();
-  const tiers: MapSummary["tiers"] = [];
-  for (const [index, rawTier] of value.tiers.entries()) {
-    if (!isSnapshotRecord(rawTier) || typeof rawTier.tier !== "string" || !TIER_ORDER.includes(rawTier.tier as Tier)) {
-      malformedSnapshot(path, `mapSummary.tiers[${index}].tier is invalid`);
-    }
-    const tier = rawTier.tier as Tier;
-    if (seenTiers.has(tier)) malformedSnapshot(path, `mapSummary.tiers contains duplicate ${tier}`);
-    seenTiers.add(tier);
-    if (typeof rawTier.range !== "string" || rawTier.range.length === 0) malformedSnapshot(path, `mapSummary.tiers[${index}].range is invalid`);
-    const count = nonNegativeInteger(rawTier.count, `mapSummary.tiers[${index}].count`, path);
-    if (typeof rawTier.mcapUsd !== "number" || !Number.isFinite(rawTier.mcapUsd) || rawTier.mcapUsd < 0) malformedSnapshot(path, `mapSummary.tiers[${index}].mcapUsd is invalid`);
-    if (typeof rawTier.sharePct !== "number" || !Number.isFinite(rawTier.sharePct) || rawTier.sharePct < 0) malformedSnapshot(path, `mapSummary.tiers[${index}].sharePct is invalid`);
-    if (!Array.isArray(rawTier.leaders) || rawTier.leaders.length > 3) malformedSnapshot(path, `mapSummary.tiers[${index}].leaders is invalid`);
-    const leaders = rawTier.leaders.map((rawLeader, leaderIndex) => {
-      if (!isSnapshotRecord(rawLeader) || typeof rawLeader.symbol !== "string" || rawLeader.symbol.length === 0) malformedSnapshot(path, `mapSummary.tiers[${index}].leaders[${leaderIndex}] is invalid`);
-      if (typeof rawLeader.score !== "number" || !Number.isFinite(rawLeader.score) || rawLeader.score < 0 || rawLeader.score > 100) malformedSnapshot(path, `mapSummary.tiers[${index}].leaders[${leaderIndex}].score is invalid`);
-      if (typeof rawLeader.mcapUsd !== "number" || !Number.isFinite(rawLeader.mcapUsd) || rawLeader.mcapUsd < 0) malformedSnapshot(path, `mapSummary.tiers[${index}].leaders[${leaderIndex}].mcapUsd is invalid`);
-      return { symbol: rawLeader.symbol, score: rawLeader.score, mcapUsd: rawLeader.mcapUsd };
-    });
-    tiers.push({ tier, range: rawTier.range, count, mcapUsd: rawTier.mcapUsd, sharePct: rawTier.sharePct, leaders });
-  }
-  if (seenTiers.size !== TIER_ORDER.length) malformedSnapshot(path, "mapSummary.tiers is missing a grade band");
-  return {
-    date: value.date,
-    asOfSec: value.asOfSec,
-    methodologyVersion: value.methodologyVersion,
-    gradedCount,
-    notRatedCount,
-    totalMcapUsd: value.totalMcapUsd,
-    floorMcapByTier: { a: value.floorMcapByTier.a, other: value.floorMcapByTier.other },
-    tiers,
-  };
-}
-
-function readPreviousSnapshot(path: string): PreviousSnapshot | null {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(readFileSync(resolve(path), "utf8"));
-  } catch (err) {
-    const code = isSnapshotRecord(err) && typeof err.code === "string" ? err.code : null;
-    if (code === "ENOENT") {
-      console.warn(`[safety-score-map] Could not read --previous-snapshot ${path} (file not found) — delta guard skipped`);
-      return null;
-    }
-    if (err instanceof SyntaxError) malformedSnapshot(path, "JSON could not be parsed");
-    throw new Error(`[safety-score-map] Could not read --previous-snapshot ${path} (${err instanceof Error ? err.message : String(err)})`);
-  }
-  if (!isSnapshotRecord(raw)) malformedSnapshot(path, "root must be an object");
-  if (raw.publicationStatus !== "current") malformedSnapshot(path, "publicationStatus must be current");
-  const counts = raw.counts;
-  if (!isSnapshotRecord(counts)) malformedSnapshot(path, "counts is missing");
-  const graded = nonNegativeInteger(counts.graded, "counts.graded", path);
-  const notRated = nonNegativeInteger(counts.notRated, "counts.notRated", path);
-  const unjoined = nonNegativeInteger(counts.unjoined, "counts.unjoined", path);
-  const missingLogos = nonNegativeInteger(counts.missingLogos, "counts.missingLogos", path);
-  const rawByTier = counts.byTier;
-  if (!isSnapshotRecord(rawByTier)) malformedSnapshot(path, "counts.byTier is missing");
-  const byTier = Object.fromEntries(TIER_ORDER.map((tier) => {
-    if (!(tier in rawByTier)) malformedSnapshot(path, `counts.byTier.${tier} is missing`);
-    return [tier, nonNegativeInteger(rawByTier[tier], `counts.byTier.${tier}`, path)];
-  })) as Record<Tier, number>;
-  if (Object.keys(rawByTier).some((tier) => !TIER_ORDER.includes(tier as Tier))) malformedSnapshot(path, "counts.byTier contains an unknown tier");
-  if (Object.values(byTier).reduce((sum, count) => sum + count, 0) !== graded) malformedSnapshot(path, "counts.byTier does not sum to counts.graded");
-  if (unjoined > graded || missingLogos > graded) malformedSnapshot(path, "counts has an impossible census value");
-
-  if (!Array.isArray(raw.coins)) malformedSnapshot(path, "coins is missing");
-  const coins = raw.coins.map((coin, index) => parseSnapshotCoin(coin, index, path));
-  if (coins.length !== graded) malformedSnapshot(path, "coins length does not match counts.graded");
-  const coinIds = new Set<string>();
-  for (const coin of coins) {
-    if (coinIds.has(coin.id)) malformedSnapshot(path, `coins contains duplicate ${coin.id}`);
-    coinIds.add(coin.id);
-  }
-  const mapSummary = parseSnapshotMapSummary(raw.mapSummary, path);
-  if (mapSummary.gradedCount !== graded || mapSummary.notRatedCount !== notRated) malformedSnapshot(path, "mapSummary counts disagree with counts");
-  const summaryByTier = new Map(mapSummary.tiers.map((tier) => [tier.tier, tier]));
-  for (const tier of TIER_ORDER) {
-    if (summaryByTier.get(tier)!.count !== byTier[tier]) malformedSnapshot(path, `mapSummary.${tier} count disagrees with counts.byTier`);
-  }
-  const totalSummaryMcap = mapSummary.tiers.reduce((sum, tier) => sum + tier.mcapUsd, 0);
-  if (Math.abs(totalSummaryMcap - mapSummary.totalMcapUsd) > Math.max(1, mapSummary.totalMcapUsd * 1e-9)) malformedSnapshot(path, "mapSummary tier supply does not sum to totalMcapUsd");
-  return { publicationStatus: "current", counts: { graded, notRated, unjoined, missingLogos, byTier }, mapSummary, coins };
-}
-
-function assertSaneDeltas(
-  path: string | null,
-  current: CurrentDeltaState,
-  acceptSnapshotTransition = false,
-): void {
-  if (!path) {
-    console.warn("[safety-score-map] No --previous-snapshot supplied — day-over-day delta guard skipped");
-    return;
-  }
-  const previous = readPreviousSnapshot(path);
-  if (!previous) {
-    if (acceptSnapshotTransition) {
-      throw new Error("--accept-snapshot-transition requires a readable --previous-snapshot");
-    }
-    return;
-  }
-  if (acceptSnapshotTransition) {
-    console.warn("[safety-score-map] Operator accepted the validated previous snapshot transition — day-over-day comparisons skipped");
-    return;
-  }
-  const priorGraded = previous.counts.graded;
-  const priorNotRated = previous.counts.notRated;
-  if (current.gradedCount < priorGraded * (1 - MAX_GRADED_DROP)) {
-    throw new DeltaGuardRejection(
-      `Graded count fell from ${priorGraded} to ${current.gradedCount} (>${MAX_GRADED_DROP * 100}%) since the previous snapshot — refusing to publish a shrunken census`,
-    );
-  }
-  if (Math.abs(current.notRatedCount - priorNotRated) > MAX_NOT_RATED_MOVE) {
-    throw new DeltaGuardRejection(
-      `Not-rated count moved from ${priorNotRated} to ${current.notRatedCount} (>${MAX_NOT_RATED_MOVE}) since the previous snapshot — the scoring producer looks half-broken`,
-    );
-  }
-
-  const priorById = new Map(previous.coins.map((coin) => [coin.id, coin]));
-  const currentByTier = new Map(current.tiers.map((tier) => [tier.tier, tier]));
-  for (const tier of TIER_ORDER) {
-    const priorCount = previous.counts.byTier[tier];
-    const currentCount = currentByTier.get(tier)!.count;
-    const allowedMove = Math.max(2, Math.ceil(priorCount * MAX_GRADED_DROP));
-    if (Math.abs(currentCount - priorCount) > allowedMove) {
-      throw new DeltaGuardRejection(`Tier ${tier} count moved from ${priorCount} to ${currentCount} (> ${allowedMove}) since the previous snapshot — refusing an unexplained reclassification`);
-    }
-
-    const priorTier = previous.mapSummary.tiers.find((entry) => entry.tier === tier)!;
-    const currentTier = currentByTier.get(tier)!;
-    const mcapDelta = Math.abs(currentTier.mcap - priorTier.mcapUsd);
-    if (mcapDelta > Math.max(1, priorTier.mcapUsd * 0.25)) {
-      throw new DeltaGuardRejection(`Tier ${tier} supply moved from ${priorTier.mcapUsd} to ${currentTier.mcap} (>25%) since the previous snapshot — refusing an unexplained supply shift`);
-    }
-    const priorLeader = priorTier.leaders[0];
-    const currentLeader = currentTier.leaders[0];
-    if ((priorLeader == null) !== (currentLeader == null)) {
-      throw new DeltaGuardRejection(`Tier ${tier} leader changed since the previous snapshot — refusing an unexplained leader shift`);
-    }
-    if (priorLeader != null && currentLeader != null) {
-      if (priorLeader.symbol === currentLeader.symbol) {
-        if (Math.abs(currentLeader.mcap - priorLeader.mcapUsd) > Math.max(1, priorLeader.mcapUsd * 0.25)) {
-          throw new DeltaGuardRejection(`Tier ${tier} leader supply moved from ${priorLeader.mcapUsd} to ${currentLeader.mcap} (>25%) since the previous snapshot — refusing an unexplained leader shift`);
-        }
-      } else {
-        // A swap between near-tied coins is ordinary market movement (the
-        // 2026-08-29 BUIDL/USYC flip sat 0.6% apart, failed both scheduled
-        // runs, and blocked the digest map), so a new leader is accepted when
-        // the prior census already knew the coin and its own supply moved
-        // within the same 25% tolerance. A leader the prior census never saw
-        // still reads as a broken join or census fault and fails closed.
-        const priorCoin = priorById.get(currentLeader.id);
-        if (priorCoin == null) {
-          throw new DeltaGuardRejection(`Tier ${tier} leader changed to ${currentLeader.symbol}, absent from the previous census — refusing an unexplained leader shift`);
-        }
-        if (Math.abs(currentLeader.mcap - priorCoin.mcap) > Math.max(1, priorCoin.mcap * 0.25)) {
-          throw new DeltaGuardRejection(`Tier ${tier} leader ${currentLeader.symbol} supply moved from ${priorCoin.mcap} to ${currentLeader.mcap} (>25%) since the previous snapshot — refusing an unexplained leader shift`);
-        }
-      }
-    }
-  }
-
-  const currentById = new Map(current.coins.map((coin) => [coin.id, coin]));
-  const allIds = new Set([...priorById.keys(), ...currentById.keys()]);
-  // Census additions/removals are deliberately not join flips — they are
-  // already bounded by the graded-count, tier-count, tier-supply and leader
-  // guards above. Counting them here failed the run the day after any coin
-  // entered the census (2026-08-26: hollar-hydrated moving NR -> graded under
-  // methodology 9.44 blocked the daily publication and the digest map, and a
-  // failed run never advances the snapshot baseline, so every later run kept
-  // failing against the same stale census).
-  const joinChanges = [...allIds].filter((id) => {
-    const prior = priorById.get(id);
-    const next = currentById.get(id);
-    return prior != null && next != null && (prior.mcap > 0) !== (next.mcap > 0);
-  });
-  if (joinChanges.length > 0) {
-    const flippedMcap = joinChanges.reduce(
-      (sum, id) => sum + Math.max(priorById.get(id)!.mcap, currentById.get(id)!.mcap),
-      0,
-    );
-    const maxFlippedMcap = previous.mapSummary.totalMcapUsd * MAX_JOIN_FLIP_MCAP_SHARE;
-    const detail = `${joinChanges.length} coin(s) since the previous snapshot (${joinChanges.slice(0, 5).join(", ")}; $${Math.round(flippedMcap).toLocaleString("en-US")} affected)`;
-    if (joinChanges.length > MAX_JOIN_FLIPS || flippedMcap > maxFlippedMcap) {
-      throw new DeltaGuardRejection(
-        `Supply join identity changed for ${detail} — beyond the tolerance of ${MAX_JOIN_FLIPS} coins and ${MAX_JOIN_FLIP_MCAP_SHARE * 100}% of mapped supply ($${Math.round(maxFlippedMcap).toLocaleString("en-US")}), refusing to publish an ambiguous census`,
-      );
-    }
-    console.warn(
-      `[safety-score-map] Supply join identity changed for ${detail} — within tolerance, publishing from the current supply state (a coin that lost its join draws at the size floor)`,
-    );
-  }
-  const gradeTransitions = [...allIds].filter((id) => {
-    const prior = priorById.get(id);
-    const next = currentById.get(id);
-    return prior != null && next != null && prior.grade !== next.grade;
-  });
-  const maxGradeTransitions = Math.max(5, Math.ceil(priorGraded * 0.1));
-  if (gradeTransitions.length > maxGradeTransitions) {
-    throw new DeltaGuardRejection(`Per-coin grade transitions moved ${gradeTransitions.length} assets (> ${maxGradeTransitions}) since the previous snapshot — the scoring producer looks half-broken`);
-  }
-  if (current.missingLogoCount != null && previous.counts.missingLogos !== current.missingLogoCount) {
-    throw new DeltaGuardRejection(`Missing-logo count moved from ${previous.counts.missingLogos} to ${current.missingLogoCount} since the previous snapshot — refusing an unexplained asset change`);
-  }
-  console.log(`[safety-score-map] Delta guard OK vs previous snapshot (graded ${priorGraded} -> ${current.gradedCount}, not rated ${priorNotRated} -> ${current.notRatedCount})`);
-}
-
-function assertMissingLogoDelta(
-  path: string | null,
-  missingLogoCount: number,
-  acceptSnapshotTransition = false,
-): void {
-  if (!path || acceptSnapshotTransition) return;
-  const previous = readPreviousSnapshot(path);
-  if (!previous) return;
-  if (previous.counts.missingLogos !== missingLogoCount) {
-    throw new DeltaGuardRejection(`Missing-logo count moved from ${previous.counts.missingLogos} to ${missingLogoCount} since the previous snapshot — refusing an unexplained asset change`);
-  }
-}
-
 interface PreparedMapData {
   reportCardsResult: FetchJsonResult;
   reportCards: ReturnType<typeof parseMapReportCards>;
@@ -2283,12 +1905,8 @@ interface PreparedMapData {
 async function fetchAndValidateMapData(
   apiKey: string,
   baseUrl: string,
-  previousSnapshot: string | null,
-  acceptSnapshotTransition: boolean,
-  attempt: number,
-  retryStatus: DeltaGuardRetryStatus,
 ): Promise<PreparedMapData> {
-  console.log(`[safety-score-map] Fetching live data from ${baseUrl} (validation attempt ${attempt}/${MAX_DELTA_GUARD_ATTEMPTS})`);
+  console.log(`[safety-score-map] Fetching canonical data from ${baseUrl}`);
   const [reportCardsResult, listResult, psiResult] = await Promise.all([
     fetchJson(API_PATHS.reportCardsV9(), apiKey, baseUrl),
     fetchJson(API_PATHS.stablecoins(), apiKey, baseUrl),
@@ -2297,14 +1915,7 @@ async function fetchAndValidateMapData(
   const reportCards = parseMapReportCards(reportCardsResult.body);
   const list = parseMapStablecoins(listResult.body);
   const psi = selectMapPsi(parseMapPsi(psiResult.body));
-  if (reportCardsResult.publicationStatus !== "current") {
-    throw new Error(`Report-card publication status is "${reportCardsResult.publicationStatus ?? "missing"}" — refusing to render a non-current capture`);
-  }
-
   const nowSec = Math.floor(Date.now() / 1000);
-  const ageSec = nowSec - reportCards.asOfSec;
-  if (ageSec < 0) throw new Error(`Report-card capture is ${(ageSec / 3600).toFixed(1)}h old — refusing to render a future-dated capture`);
-  if (ageSec >= MAX_DATA_AGE_SEC) throw new Error(`Report-card capture is ${(ageSec / 3600).toFixed(1)}h old (must be under ${MAX_DATA_AGE_SEC / 3600}h) — refusing to render stale scores`);
   const psiAgeSec = nowSec - psi.computedAt;
   if (psiAgeSec < 0) throw new Error(`PSI reading is ${(psiAgeSec / 60).toFixed(1)}m old — refusing to render a future-dated level`);
   if (psiAgeSec >= API_FRESHNESS_MAX_AGE_SEC.stabilityIndex) throw new Error(`PSI reading is ${(psiAgeSec / 60).toFixed(1)}m old (must be under ${API_FRESHNESS_MAX_AGE_SEC.stabilityIndex / 60}m) — refusing to render a stale level`);
@@ -2334,9 +1945,6 @@ async function fetchAndValidateMapData(
 
   const tiers = summarizeMapCoins(graded);
   const lanes = summarizeSubgradeLanes(graded);
-  const initialObservedTiers = Object.fromEntries(tiers.map((tier) => [tier.tier, { count: tier.count, mcap: tier.mcap }])) as Record<Tier, { count: number; mcap: number }>;
-  console.log(`[safety-score-map] Validation attempt ${attempt}/${MAX_DELTA_GUARD_ATTEMPTS} observed graded=${graded.length} notRated=${notRatedCount} missingLogos=pending ${TIER_ORDER.map((tier) => `${tier}=${initialObservedTiers[tier].count}/${initialObservedTiers[tier].mcap}`).join(" ")}`);
-  assertSaneDeltas(previousSnapshot, { gradedCount: graded.length, notRatedCount, missingLogoCount: null, coins: graded, tiers }, acceptSnapshotTransition);
 
   const { bands, k, gravelFloor } = fitLayout(graded);
   const logos = new Map<string, LogoRenderData | null>();
@@ -2349,9 +1957,7 @@ async function fetchAndValidateMapData(
   const missingLogos = allBubbles.filter((bubble) => !logos.get(bubble.coin.id));
   if (missingLogos.length > 0) console.warn(`[safety-score-map] No logo for ${missingLogos.length} coins: ${missingLogos.slice(0, 12).map((b) => b.coin.id).join(", ")}${missingLogos.length > 12 ? ", …" : ""}`);
 
-  retryStatus.observed.push({ attempt, graded: graded.length, notRated: notRatedCount, missingLogos: missingLogos.length, tiers: initialObservedTiers });
-  console.log(`[safety-score-map] Validation attempt ${attempt}/${MAX_DELTA_GUARD_ATTEMPTS} observed graded=${graded.length} notRated=${notRatedCount} missingLogos=${missingLogos.length} ${TIER_ORDER.map((tier) => `${tier}=${initialObservedTiers[tier].count}/${initialObservedTiers[tier].mcap}`).join(" ")}`);
-  assertMissingLogoDelta(previousSnapshot, missingLogos.length, acceptSnapshotTransition);
+  console.log(`[safety-score-map] Render input graded=${graded.length} notRated=${notRatedCount} missingLogos=${missingLogos.length}`);
   return { reportCardsResult, reportCards, psi, graded, unjoined, notRatedCount, tiers, lanes, bands, k, gravelFloor, logos, missingLogos };
 }
 
@@ -2394,40 +2000,12 @@ function fitLayout(graded: readonly MapCoin[]): { bands: BandLayout[]; k: number
 }
 
 async function main(): Promise<void> {
-  const { out, edition, issue, previousSnapshot, acceptSnapshotTransition } = parseCliArgs(process.argv.slice(2));
+  const { out, edition, issue } = parseCliArgs(process.argv.slice(2));
   unsupportedGlyphs.clear();
   const apiKey = loadApiKey();
   const baseUrl = process.env.PHAROS_API_BASE?.trim() || DEFAULT_MAINTENANCE_API_BASE_URL;
 
-  const retryStatus: DeltaGuardRetryStatus = { attempts: 0, recovered: false, persistent: false, rejections: [], observed: [] };
-  let prepared: PreparedMapData | null = null;
-  for (let attempt = 1; attempt <= MAX_DELTA_GUARD_ATTEMPTS; attempt += 1) {
-    try {
-      prepared = await fetchAndValidateMapData(apiKey, baseUrl, previousSnapshot, acceptSnapshotTransition, attempt, retryStatus);
-      retryStatus.attempts = attempt;
-      retryStatus.recovered = retryStatus.rejections.length > 0;
-      writeDeltaGuardRetryStatus(retryStatus);
-      if (retryStatus.recovered) console.log(`[safety-score-map] Delta guard transient rejection recovered on attempt ${attempt} after ${retryStatus.rejections.length} rejected attempt(s)`);
-      break;
-    } catch (error) {
-      if (!(error instanceof DeltaGuardRejection)) {
-        retryStatus.attempts = attempt;
-        writeDeltaGuardRetryStatus(retryStatus);
-        throw error;
-      }
-      retryStatus.attempts = attempt;
-      retryStatus.rejections.push(error.message);
-      console.warn(`[safety-score-map] Validation attempt ${attempt}/${MAX_DELTA_GUARD_ATTEMPTS} rejected by delta guard: ${error.message}`);
-      writeDeltaGuardRetryStatus(retryStatus);
-      if (attempt === MAX_DELTA_GUARD_ATTEMPTS) {
-        retryStatus.persistent = true;
-        writeDeltaGuardRetryStatus(retryStatus);
-        throw new Error(`Persistent delta guard rejection after ${MAX_DELTA_GUARD_ATTEMPTS} attempts — ${error.message}`);
-      }
-      await sleep(DELTA_GUARD_BACKOFF_MS[attempt - 1]);
-    }
-  }
-  if (!prepared) throw new Error("Safety map validation did not produce a snapshot");
+  const prepared = await fetchAndValidateMapData(apiKey, baseUrl);
   const { reportCardsResult, reportCards, psi, graded, unjoined, notRatedCount, tiers, lanes, bands, k, gravelFloor, logos, missingLogos } = prepared;
   const totalMcap = graded.reduce((sum, coin) => sum + coin.mcap, 0);
   const floorMcapByTier: FloorMcapByTier = {
@@ -2579,8 +2157,6 @@ async function main(): Promise<void> {
     floorMcapByTier,
     tiers,
   });
-  // One header shape, shared by the snapshot and the manifest: it is both the
-  // movers baseline and the input the next run's delta guard reads back.
   const counts = {
     graded: graded.length,
     notRated: notRatedCount,
@@ -2596,26 +2172,6 @@ async function main(): Promise<void> {
     `${JSON.stringify({ edition, date: runDate, asOfSec: reportCards.asOfSec, psi, altText, table, tiers }, null, 2)}\n`,
   );
   writeFileSync(
-    sidecar(".snapshot.json"),
-    `${JSON.stringify(
-      {
-        edition,
-        date: runDate,
-        publicationStatus: reportCardsResult.publicationStatus,
-        asOfSec: reportCards.asOfSec,
-        renderedAtSec,
-        methodologyVersion: reportCards.methodologyVersion,
-        updatedAt: reportCards.updatedAt,
-        publicationHealth: reportCards.publicationHealth,
-        counts,
-        mapSummary,
-        coins: graded.map((coin) => ({ id: coin.id, symbol: coin.symbol, score: coin.score, grade: coin.grade, mcap: coin.mcap })),
-      },
-      null,
-      2,
-    )}\n`,
-  );
-  writeFileSync(
     manifestPath,
     `${JSON.stringify(
       {
@@ -2626,9 +2182,12 @@ async function main(): Promise<void> {
         renderedAtSec,
         asOfSec: reportCards.asOfSec,
         methodologyVersion: reportCards.methodologyVersion,
+        updatedAt: reportCards.updatedAt,
+        publicationHealth: reportCards.publicationHealth,
         counts,
         totalMcap,
         bytes: statSync(pngPath).size,
+        mapSummary,
       },
       null,
       2,

--- a/scripts/maintenance/publish-safety-score-map.ts
+++ b/scripts/maintenance/publish-safety-score-map.ts
@@ -7,7 +7,6 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -19,7 +18,6 @@ import { runShellCommand, type CommandImplementation } from "../lib/command-runn
 
 const execFileAsync = promisify(execFile);
 const MANIFEST_KEY = "safety-map:latest.json";
-const SNAPSHOT_LATEST_KEY = "safety-map:snapshot:latest";
 const FRESH_SAME_DAY_SECONDS = 6 * 3600;
 const MAX_MANIFEST_BYTES = 16_384;
 
@@ -35,8 +33,6 @@ Options:
   --state <path>         Run-state JSON (default: agents/safety-score-map/ci/publish-state.json)
   --out-dir <path>       Render output directory (default: agents/safety-score-map/ci)
   --event-name <name>    GitHub event name (plan; default: GITHUB_EVENT_NAME or workflow_dispatch)
-  --accept-snapshot-transition
-                         Manual plan only: accept the current live snapshot as an audited transition
   --job-status <status>  GitHub job status (summary; default: unknown)
   --dry-run              Plan only: inspect and print the decision without KV writes
   -h, --help             Show this help`;
@@ -53,9 +49,12 @@ interface SafetyMapManifest {
   renderedAtSec: unknown;
   edition: unknown;
   methodologyVersion: unknown;
+  publicationStatus: unknown;
+  updatedAt: unknown;
+  publicationHealth: unknown;
   counts: Record<string, unknown>;
   mapSummary?: unknown;
-  bytes: { png: number; alt: number; snapshot: number };
+  bytes: { png: number; alt: number };
 }
 
 export interface SafetyMapPublishState {
@@ -64,18 +63,10 @@ export interface SafetyMapPublishState {
   plannedAtSec: number;
   alreadyPublished: boolean;
   hadManifest: boolean;
-  acceptedSnapshotTransition?: boolean;
-  deltaGuard: "ran" | "recovered" | "persistent" | "accepted" | "skipped" | "not reached";
-  previousSnapshotPath?: string;
   priorManifest?: Record<string, unknown>;
   manifest?: SafetyMapManifest;
   manifestPath?: string;
   renderSeconds?: number;
-}
-
-interface RetryStatus {
-  recovered?: boolean;
-  persistent?: boolean;
 }
 
 export interface PublicationIo {
@@ -183,7 +174,6 @@ function parseManifest(raw: Buffer): Record<string, unknown> {
 export async function planSafetyMapPublication({
   adapter,
   dryRun = false,
-  acceptSnapshotTransition = false,
   eventName,
   io = DEFAULT_IO,
   nowSec = Math.floor(Date.now() / 1000),
@@ -191,21 +181,13 @@ export async function planSafetyMapPublication({
 }: {
   adapter: SafetyMapKvAdapter;
   dryRun?: boolean;
-  acceptSnapshotTransition?: boolean;
   eventName: string;
   io?: PublicationIo;
   nowSec?: number;
   statePath: string;
 }): Promise<SafetyMapPublishState> {
-  if (acceptSnapshotTransition && eventName !== "workflow_dispatch") {
-    throw new Error("--accept-snapshot-transition is restricted to workflow_dispatch runs");
-  }
-  const [manifestNames, snapshotNames] = await Promise.all([
-    adapter.list(MANIFEST_KEY),
-    adapter.list(SNAPSHOT_LATEST_KEY),
-  ]);
+  const manifestNames = await adapter.list(MANIFEST_KEY);
   const hadManifest = manifestNames.includes(MANIFEST_KEY);
-  const hasPreviousSnapshot = snapshotNames.includes(SNAPSHOT_LATEST_KEY);
   const priorManifest = hadManifest ? parseManifest(await adapter.get(MANIFEST_KEY, { text: true })) : undefined;
 
   const today = utcDate(nowSec);
@@ -218,8 +200,6 @@ export async function planSafetyMapPublication({
     plannedAtSec: nowSec,
     alreadyPublished,
     hadManifest,
-    ...(acceptSnapshotTransition ? { acceptedSnapshotTransition: true } : {}),
-    deltaGuard: "not reached",
     ...(priorManifest ? { priorManifest } : {}),
   };
 
@@ -227,35 +207,6 @@ export async function planSafetyMapPublication({
   io.stdout.write(alreadyPublished
     ? `Manifest for ${today} is live with data ${Math.round(ageSec / 60)}m old — skipping the re-render.\n`
     : `Proceeding: manifest date=${priorManifest?.date ?? "none"}, today=${today}, event=${eventName}, data age=${Math.round(ageSec / 60)}m.\n`);
-
-  if (acceptSnapshotTransition && !hasPreviousSnapshot) {
-    throw new Error(`Cannot accept a snapshot transition without a live ${SNAPSHOT_LATEST_KEY} baseline`);
-  }
-
-  if (!alreadyPublished && hasPreviousSnapshot) {
-    const previousSnapshotPath = join(dirname(statePath), "previous-snapshot.json");
-    if (!dryRun) rmSync(previousSnapshotPath, { force: true });
-    try {
-      const raw = await adapter.get(SNAPSHOT_LATEST_KEY, { text: true });
-      const previous = asObject(extractJson(raw, "{"), "previous snapshot is not a JSON object");
-      if (!("publicationStatus" in previous)) {
-        if (acceptSnapshotTransition) throw new Error(`${SNAPSHOT_LATEST_KEY} predates the current publication-status contract`);
-        io.warning("Legacy previous snapshot", `${SNAPSHOT_LATEST_KEY} predates the current publication-status contract. The delta guard will be skipped once.`);
-      } else if (!dryRun) {
-        mkdirSync(dirname(previousSnapshotPath), { recursive: true });
-        writeFileSync(previousSnapshotPath, JSON.stringify(previous), "utf8");
-        state.previousSnapshotPath = previousSnapshotPath;
-        io.stdout.write(`Previous snapshot: date=${previous.date} graded=${(previous.counts as Record<string, unknown> | undefined)?.graded} notRated=${(previous.counts as Record<string, unknown> | undefined)?.notRated}\n`);
-      }
-    } catch (error) {
-      if (acceptSnapshotTransition) {
-        throw new Error(`Cannot accept a snapshot transition without a readable current ${SNAPSHOT_LATEST_KEY} baseline`, { cause: error });
-      }
-      io.warning("Previous snapshot unreadable", `${SNAPSHOT_LATEST_KEY} could not be read as current JSON. The delta guard will be skipped. ${error instanceof Error ? error.message : String(error)}`);
-    }
-  } else if (!dryRun) {
-    rmSync(join(dirname(statePath), "previous-snapshot.json"), { force: true });
-  }
 
   if (!dryRun) writeState(statePath, state);
   io.writeOutput("already_published", alreadyPublished);
@@ -266,24 +217,27 @@ export async function planSafetyMapPublication({
 function buildManifest(outDir: string): { manifest: SafetyMapManifest; manifestPath: string } {
   const png = join(outDir, "latest.png");
   const alt = join(outDir, "latest.alt.json");
-  const snapshot = join(outDir, "latest.snapshot.json");
-  const meta = asObject(JSON.parse(readFileSync(snapshot, "utf8")), "latest.snapshot.json must be an object");
+  const renderManifest = join(outDir, "latest.manifest.json");
+  const meta = asObject(JSON.parse(readFileSync(renderManifest, "utf8")), "latest.manifest.json must be an object");
   const required = ["date", "asOfSec", "renderedAtSec", "edition", "counts"];
   const absent = required.filter((key) => meta[key] === undefined || meta[key] === null);
-  if (absent.length > 0) throw new Error(`latest.snapshot.json is missing ${absent.join(", ")}. The generator output contract changed.`);
+  if (absent.length > 0) throw new Error(`latest.manifest.json is missing ${absent.join(", ")}. The generator output contract changed.`);
   if (meta.edition !== "daily") throw new Error(`Rendered edition is "${meta.edition}", expected "daily".`);
   if (typeof meta.date !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(meta.date)) throw new Error(`Bad archive date: "${meta.date}" is not YYYY-MM-DD.`);
   const runDate = utcDate(Number(meta.renderedAtSec));
-  if (meta.date !== runDate) throw new Error(`Archive date is not the run date: snapshot says ${meta.date}, renderedAtSec resolves to ${runDate} UTC.`);
+  if (meta.date !== runDate) throw new Error(`Archive date is not the run date: render manifest says ${meta.date}, renderedAtSec resolves to ${runDate} UTC.`);
   const manifest: SafetyMapManifest = {
     date: meta.date,
     asOfSec: meta.asOfSec,
     renderedAtSec: meta.renderedAtSec,
     edition: meta.edition,
     methodologyVersion: meta.methodologyVersion ?? null,
-    counts: asObject(meta.counts, "latest.snapshot.json counts must be an object"),
+    publicationStatus: meta.publicationStatus ?? null,
+    updatedAt: meta.updatedAt ?? null,
+    publicationHealth: meta.publicationHealth ?? null,
+    counts: asObject(meta.counts, "latest.manifest.json counts must be an object"),
     ...(meta.mapSummary === undefined ? {} : { mapSummary: meta.mapSummary }),
-    bytes: { png: statSync(png).size, alt: statSync(alt).size, snapshot: statSync(snapshot).size },
+    bytes: { png: statSync(png).size, alt: statSync(alt).size },
   };
   const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
   if (Buffer.byteLength(manifestText, "utf8") >= MAX_MANIFEST_BYTES) throw new Error(`KV manifest is ${Buffer.byteLength(manifestText, "utf8")} bytes; it must stay under ${MAX_MANIFEST_BYTES} bytes.`);
@@ -305,28 +259,10 @@ export async function renderSafetyMapPublication({
 }): Promise<SafetyMapPublishState> {
   const state = readState(statePath);
   if (state.alreadyPublished) return state;
-  const previousSnapshotPath = state.previousSnapshotPath ?? join(dirname(statePath), "previous-snapshot.json");
-  const retryStatusPath = join(outDir, "latest.retry.json");
-  rmSync(retryStatusPath, { force: true });
-  state.deltaGuard = state.acceptedSnapshotTransition
-    ? "accepted"
-    : existsSync(previousSnapshotPath) && statSync(previousSnapshotPath).size > 0 ? "ran" : "skipped";
-  if (state.deltaGuard === "skipped") io.warning("Delta guard skipped", `No readable ${SNAPSHOT_LATEST_KEY}; unconditional render guards still apply.`);
-  if (state.deltaGuard === "accepted") io.warning("Snapshot transition accepted", `The operator accepted the current live ${SNAPSHOT_LATEST_KEY} baseline transition; unconditional render guards still apply.`);
   const started = Date.now();
-  const command = `npm run build:safety-score-map -- --out ${shellQuote(join(outDir, "latest.png"))} --previous-snapshot ${shellQuote(previousSnapshotPath)}${state.deltaGuard === "accepted" ? " --accept-snapshot-transition" : ""}`;
-  const result = await commandRunner(command, { SAFETY_MAP_RETRY_STATUS_PATH: retryStatusPath }, {});
+  const command = `npm run build:safety-score-map -- --out ${shellQuote(join(outDir, "latest.png"))}`;
+  const result = await commandRunner(command, {}, {});
   const status = typeof result === "number" ? result : result.status;
-  let retryStatus: RetryStatus | null = null;
-  if (existsSync(retryStatusPath)) {
-    try {
-      retryStatus = JSON.parse(readFileSync(retryStatusPath, "utf8")) as RetryStatus;
-    } catch {
-      io.warning("Retry status unreadable", "The render completed without a readable retry-status record.");
-    }
-  }
-  if (retryStatus?.recovered) state.deltaGuard = "recovered";
-  if (retryStatus?.persistent) state.deltaGuard = "persistent";
   if (status !== 0) {
     writeState(statePath, state);
     throw new Error(`Safety Map render failed with status ${status}`);
@@ -341,8 +277,6 @@ export async function renderSafetyMapPublication({
 export function safetyMapPublicationEntries(state: SafetyMapPublishState, outDir: string): Array<{ key: string; path: string; verify?: true }> {
   if (!state.manifest || !state.manifestPath) throw new Error("Publication state has no rendered manifest");
   return [
-    { key: `safety-map:snapshot:${state.manifest.date}`, path: join(outDir, "latest.snapshot.json") },
-    { key: SNAPSHOT_LATEST_KEY, path: join(outDir, "latest.snapshot.json") },
     { key: "safety-map:alt:latest", path: join(outDir, "latest.alt.json") },
     { key: `safety-map:${state.manifest.date}.png`, path: join(outDir, "latest.png"), verify: true },
     { key: "safety-map:latest.png", path: join(outDir, "latest.png") },
@@ -398,20 +332,15 @@ export function buildSafetyMapSummary(state: SafetyMapPublishState | null, jobSt
     `## Safety Map refresh — ${jobStatus}`, "", "| | |", "|---|---|",
     `| Archive date (UTC) | \`${value(manifest?.date)}\` |`,
     `| Data \`asOfSec\` | \`${value(manifest?.asOfSec)}\` |`,
+    `| Safety Score source | \`${value(manifest?.publicationStatus)}\` |`,
     `| Render started | \`${value(manifest?.renderedAtSec)}\` |`,
     `| Render wall-clock | ${value(state?.renderSeconds)}s |`,
     `| Graded coins | ${value(manifest?.counts.graded)} |`,
     `| Not rated | ${value(manifest?.counts.notRated)} |`,
     `| PNG | ${value(manifest?.bytes.png)} bytes |`,
     `| Alt text | ${value(manifest?.bytes.alt)} bytes |`,
-    `| Snapshot | ${value(manifest?.bytes.snapshot)} bytes |`,
-    `| Prior manifest existed | ${value(state?.hadManifest ?? "unknown")} |`,
-    `| Day-over-day delta guard | ${value(state?.deltaGuard ?? "not reached")} |`, "",
+    `| Prior manifest existed | ${value(state?.hadManifest ?? "unknown")} |`, "",
   ];
-  if (state?.deltaGuard === "skipped") lines.push("> **Warning:** no readable `safety-map:snapshot:latest`, so the delta guard did", "> not run this time. Expected on a first run; investigate if it repeats.", "");
-  if (state?.deltaGuard === "accepted") lines.push("> **Operator acceptance:** this manual run accepted the current live snapshot transition.", "> Unconditional freshness, geometry, composition, font, and raster guards still ran.", "");
-  if (state?.deltaGuard === "recovered") lines.push("> **Transient rejection recovered:** a delta guard rejected an upstream read, then a fresh retry passed. The published map uses the recovered attempt.", "");
-  if (state?.deltaGuard === "persistent") lines.push("> **Persistent delta rejection:** all three fresh validation attempts agreed on the shift. Nothing was published; human review with `--accept-snapshot-transition` is still required.", "");
   if (state?.alreadyPublished) {
     lines.push("### Skipped — today is already published", "", "The live `safety-map:latest.json` already carries today's date with fresh", "data, so this scheduled retry slot exited without rendering or writing.");
   } else if (jobStatus === "success" && state?.phase === "published" && manifest) {
@@ -433,7 +362,6 @@ export async function runSafetyMapPublicationCli(argv: readonly string[], io: Pu
       state: { type: "string" },
       "out-dir": { type: "string" },
       "event-name": { type: "string" },
-      "accept-snapshot-transition": { type: "boolean" },
       "job-status": { type: "string" },
       "dry-run": { type: "boolean" },
     },
@@ -443,11 +371,10 @@ export async function runSafetyMapPublicationCli(argv: readonly string[], io: Pu
   const phase = positionals[0];
   assertCliUsage(["plan", "render", "publish", "summary"].includes(phase), `unknown phase: ${phase}`);
   assertCliUsage(values["dry-run"] !== true || phase === "plan", "--dry-run is only valid with plan");
-  assertCliUsage(values["accept-snapshot-transition"] !== true || phase === "plan", "--accept-snapshot-transition is only valid with plan");
   const outDir = resolve(typeof values["out-dir"] === "string" ? values["out-dir"] : "agents/safety-score-map/ci");
   const statePath = resolve(typeof values.state === "string" ? values.state : join(outDir, "publish-state.json"));
   if (phase === "plan") {
-    await planSafetyMapPublication({ adapter: defaultAdapter(), dryRun: values["dry-run"] === true, acceptSnapshotTransition: values["accept-snapshot-transition"] === true, eventName: typeof values["event-name"] === "string" ? values["event-name"] : process.env.GITHUB_EVENT_NAME ?? "workflow_dispatch", io, statePath });
+    await planSafetyMapPublication({ adapter: defaultAdapter(), dryRun: values["dry-run"] === true, eventName: typeof values["event-name"] === "string" ? values["event-name"] : process.env.GITHUB_EVENT_NAME ?? "workflow_dispatch", io, statePath });
   } else if (phase === "render") {
     await renderSafetyMapPublication({ io, outDir, statePath });
   } else if (phase === "publish") {


### PR DESCRIPTION
## Summary
- remove historical score-movement guards, retries, and manual transition overrides from the Safety Map renderer
- replace map-specific snapshot state with provenance and map summary in the existing manifest
- retain renderability validation and manifest-last publication safety

## Validation
- npm run check:pr -- --base=origin/main
- npm run check:generated-artifacts
- live production API render: 324 graded assets at 3200x1800