### PR TITLE
fix(telegram): read alert context from the thin safety envelope

### DIFF
--- a/worker/src/cron/__tests__/telegram-alert-context.test.ts
+++ b/worker/src/cron/__tests__/telegram-alert-context.test.ts
@@ -1,22 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildAlertContextLines } from "../telegram-alert-context";
-import {
-  makeWorkerReportCardsV9Response,
-  makeWorkerV9Card,
-} from "../../test-helpers/report-cards-v9";
 
 const mocks = vi.hoisted(() => ({
-  loadActiveSafetyScoreSource: vi.fn(),
+  loadActiveAlertSafetySourceAssessment: vi.fn(),
   loadStablecoinsCache: vi.fn(),
   logTelegramEvent: vi.fn(),
   getCache: vi.fn(),
   getMintBurnConfigsForStablecoin: vi.fn(),
 }));
 
-vi.mock("../../lib/safety-score-active-source", () => ({
-  loadActiveSafetyScoreSource: mocks.loadActiveSafetyScoreSource,
+vi.mock("../../lib/alert-safety-source-cache", () => ({
+  loadActiveAlertSafetySourceAssessment: mocks.loadActiveAlertSafetySourceAssessment,
 }));
+
+function safetyAssessment(
+  snapshot: Record<string, { grade: string; score: number | null; methodologyVersion: string | null }>,
+  state: "ok" | "stale" = "ok",
+) {
+  return {
+    state,
+    ageSeconds: 60,
+    generation: "safety-v9-alert-source-v1",
+    envelope: {
+      generation: "safety-v9-alert-source-v1",
+      safetyScoreIdentity: { model: "v9", schemaVersion: 1, methodologyVersion: "9.0" },
+      publicationGenerationId: "report-cards:v9:v1:test",
+      methodologyVersion: "9.0",
+      publishedAt: 1,
+      snapshot,
+    },
+  };
+}
 
 vi.mock("../../lib/stablecoins-cache", () => ({
   loadStablecoinsCache: mocks.loadStablecoinsCache,
@@ -37,11 +52,7 @@ vi.mock("../../lib/mint-burn-contracts", () => ({
 
 describe("buildAlertContextLines", () => {
   beforeEach(() => {
-    const snapshot = makeWorkerReportCardsV9Response({ cards: [] });
-    mocks.loadActiveSafetyScoreSource.mockReset().mockResolvedValue({
-      kind: "v9",
-      snapshot,
-    });
+    mocks.loadActiveAlertSafetySourceAssessment.mockReset().mockResolvedValue(safetyAssessment({}));
     mocks.loadStablecoinsCache.mockResolvedValue({ kind: "ok", payload: { peggedAssets: [] } });
     mocks.logTelegramEvent.mockReset();
     mocks.getMintBurnConfigsForStablecoin.mockReset().mockReturnValue([]);
@@ -70,8 +81,8 @@ describe("buildAlertContextLines", () => {
     expect(mocks.getCache).toHaveBeenCalledTimes(1);
   });
 
-  it("omits safety context when the canonical identity is unavailable", async () => {
-    mocks.loadActiveSafetyScoreSource.mockRejectedValueOnce(new Error("identity mismatch"));
+  it("omits safety context when the alert source assessment fails", async () => {
+    mocks.loadActiveAlertSafetySourceAssessment.mockRejectedValueOnce(new Error("identity mismatch"));
     const db = {
       prepare: vi.fn(() => ({ bind: () => ({ all: async () => ({ results: [] }) }) })),
     } as unknown as D1Database;
@@ -81,14 +92,23 @@ describe("buildAlertContextLines", () => {
     expect(context.get("usdc-circle") ?? "").not.toContain("Safety");
   });
 
-  it("includes V9 model provenance in canonical safety context", async () => {
-    const snapshot = makeWorkerReportCardsV9Response({
-      cards: [makeWorkerV9Card({ id: "usdc-circle", grade: "A", score: 85 })],
-    });
-    mocks.loadActiveSafetyScoreSource.mockResolvedValueOnce({
-      kind: "v9",
-      snapshot,
-    });
+  it("omits safety context when the alert source is not ok", async () => {
+    mocks.loadActiveAlertSafetySourceAssessment.mockResolvedValueOnce(
+      safetyAssessment({ "usdc-circle": { grade: "A", score: 85, methodologyVersion: "9.0" } }, "stale"),
+    );
+    const db = {
+      prepare: vi.fn(() => ({ bind: () => ({ all: async () => ({ results: [] }) }) })),
+    } as unknown as D1Database;
+
+    const context = await buildAlertContextLines(db, ["usdc-circle"]);
+
+    expect(context.get("usdc-circle") ?? "").not.toContain("Safety");
+  });
+
+  it("includes V9 model provenance from the thin alert envelope", async () => {
+    mocks.loadActiveAlertSafetySourceAssessment.mockResolvedValueOnce(
+      safetyAssessment({ "usdc-circle": { grade: "A", score: 85, methodologyVersion: "9.0" } }),
+    );
     const db = {
       prepare: vi.fn(() => ({ bind: () => ({ all: async () => ({ results: [] }) }) })),
     } as unknown as D1Database;

--- a/worker/src/cron/telegram-alert-context.ts
+++ b/worker/src/cron/telegram-alert-context.ts
@@ -2,7 +2,7 @@ import { formatCompactUsdWithOptions } from "@shared/lib/format";
 import { getCirculatingRaw } from "@shared/lib/supply";
 import { DEX_LIQUIDITY_PUBLISHED_ROW_FILTER } from "../lib/dex-liquidity";
 import { loadStablecoinsCache } from "../lib/stablecoins-cache";
-import { loadActiveSafetyScoreSource } from "../lib/safety-score-active-source";
+import { loadActiveAlertSafetySourceAssessment } from "../lib/alert-safety-source-cache";
 import { buildInClause, chunkArray } from "../lib/db";
 import { classifyTelegramLogError, logTelegramEvent } from "../lib/telegram-log";
 import { getMintBurnConfigsForStablecoin } from "../lib/mint-burn-contracts";
@@ -39,16 +39,19 @@ export async function buildAlertContextLines(
   if (uniqueIds.length === 0) return new Map();
   const nowSec = Math.floor(Date.now() / 1000);
 
-  const [snapshot, stablecoinsResult, liquidityResult, flowResult] = await Promise.all([
-    loadActiveSafetyScoreSource(db).then((source) =>
-      source.kind === "v9" ? source : null,
-    ).catch(() => null),
+  // The thin alert envelope carries grade/score/identity per coin. Decoding
+  // the full V9 publication here (the previous path) added an ~8MB gunzip +
+  // parse spike to every event-carrying dispatch and OOM-killed the
+  // five-minute isolate on the :27/:57 safety fan-out runs.
+  const [safety, stablecoinsResult, liquidityResult, flowResult] = await Promise.all([
+    loadActiveAlertSafetySourceAssessment(db, nowSec)
+      .then((assessment) => (assessment.state === "ok" ? assessment.envelope : null))
+      .catch(() => null),
     loadStablecoinsCache(db, { mode: "strict" }).catch(() => null),
     loadLiquidityRows(db, uniqueIds),
     loadFlowRows(db, uniqueIds, nowSec),
   ]);
 
-  const cards = new Map((snapshot?.snapshot.cards ?? []).map((card) => [card.id, card]));
   const supplies = new Map<string, number>();
   if (stablecoinsResult?.kind === "ok") {
     const wantedIds = new Set(uniqueIds);
@@ -62,11 +65,11 @@ export async function buildAlertContextLines(
   const out = new Map<string, string>();
   for (const id of uniqueIds) {
     const parts: string[] = [];
-    const card = cards.get(id);
+    const card = safety?.snapshot[id];
     const liq = liquidityResult.get(id);
     if (card) {
       parts.push(
-        `Safety ${card.grade}${card.score != null ? ` ${card.score}` : ""} (${snapshot!.snapshot.safetyScoreIdentity.model.toUpperCase()} ${snapshot!.snapshot.safetyScoreIdentity.methodologyVersion})`,
+        `Safety ${card.grade}${card.score != null ? ` ${card.score}` : ""} (${safety!.safetyScoreIdentity.model.toUpperCase()} ${safety!.safetyScoreIdentity.methodologyVersion})`,
       );
     }
     if (liq) parts.push(`Liquidity ${liq.score ?? "NR"}, DEX TVL ${formatUsdCompact(liq.tvl)}`);


### PR DESCRIPTION
## Why

After #1018 (Worker `07c1ac69`), the `:27`/`:57` safety fan-out dispatches completed, but Cloudflare still recorded `exceededMemory` for the five-minute lane at 20:27 and 20:57 UTC, abandoning the watchdog/cleanup/pulse sidecars after dispatch.

`buildAlertContextLines` (`worker/src/cron/telegram-alert-context.ts`) called `loadActiveSafetyScoreSource`, decoding the full ~8 MB V9 publication on every event-carrying dispatch and bypassing the thin alert envelope that `alert-safety-source-cache.ts` introduced after the 2026-08-19 OOM.

## What

Read grade/score/publication identity from `loadActiveAlertSafetySourceAssessment(...).envelope` (state `ok` only). Tests adapted; behaviour of the rendered `Context:` line is unchanged.

## Verification

`npm run check:pr -- --base=origin/main` green; `typecheck:worker` clean.

## Operational acceptance (pending)

First `:27`/`:57` `dispatch-telegram-alerts` run with safety events completes and its sidecars finish without a `platform-abandoned` row / `exceededMemory` outcome.
