### PR TITLE
Keep the query client in the immutable shell so static routes prerender

### DIFF
--- a/src/components/__tests__/providers-shortcuts.test.tsx
+++ b/src/components/__tests__/providers-shortcuts.test.tsx
@@ -34,7 +34,7 @@ vi.mock("next-themes", () => ({
 }));
 
 vi.mock("@/components/route-progress-bar", () => ({
-  RouteProgressBar: () => null,
+  RouteProgressBar: () => <div data-testid="route-progress-bar" />,
 }));
 
 function pressKey(key: string) {
@@ -60,7 +60,7 @@ describe("Providers single-key shortcuts (WCAG 2.1.4 disable flag)", () => {
     "/changelog/",
     "/blog/client-runtime/",
     "/methodology/scoring-changelog/",
-  ])("omits the interactive provider on the static content route %s", (staticPath) => {
+  ])("keeps the query client but omits the interactive layer on the static content route %s", async (staticPath) => {
     pathname = staticPath;
     render(
       <Providers>
@@ -69,7 +69,24 @@ describe("Providers single-key shortcuts (WCAG 2.1.4 disable flag)", () => {
     );
 
     expect(screen.getByTestId("static-child")).toBeTruthy();
-    expect(screen.queryByTestId("query-client-provider")).toBeNull();
+    // Global chrome (TopNav health menu, RegimeBar PSI) queries on every route.
+    expect(screen.getByTestId("query-client-provider")).toBeTruthy();
+    // Give the lazy interactive layer a tick so an incorrect mount would surface.
+    const tick = Promise.withResolvers<void>();
+    setTimeout(tick.resolve, 0);
+    await tick.promise;
+    expect(screen.queryByTestId("route-progress-bar")).toBeNull();
+  });
+
+  it("mounts the interactive layer on data routes", async () => {
+    pathname = "/stablecoin/usdt-tether/";
+    render(
+      <Providers>
+        <div data-testid="interactive-child" />
+      </Providers>,
+    );
+    expect(await screen.findByTestId("route-progress-bar")).toBeTruthy();
+    expect(screen.getByTestId("query-client-provider")).toBeTruthy();
   });
 
   it("broadcasts numeric column sort when single-key shortcuts are enabled", async () => {

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -3,7 +3,7 @@
 import { ThemeProvider } from "next-themes";
 import { usePathname } from "next/navigation";
 import { createContext, lazy, Suspense, useCallback, useEffect, useState } from "react";
-import type { QueryClient as QueryClientType } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 /**
  * Custom event broadcast when the user presses a numeric key (1-9) to sort
@@ -57,8 +57,7 @@ const ToastContainer = lazy(() =>
 );
 
 const InteractiveProviders = lazy(async () => {
-  const [query, toastHook, themeHook, shortcutSettings, commandPalette, routeProgress] = await Promise.all([
-    import("@tanstack/react-query"),
+  const [toastHook, themeHook, shortcutSettings, commandPalette, routeProgress] = await Promise.all([
     import("@/hooks/use-toast"),
     import("@/hooks/use-theme-toggle"),
     import("@/lib/keyboard-shortcut-settings"),
@@ -66,14 +65,7 @@ const InteractiveProviders = lazy(async () => {
     import("@/components/route-progress-bar"),
   ]);
 
-  function createPharosQueryClient(): QueryClientType {
-    return new query.QueryClient({
-      defaultOptions: PHAROS_QUERY_DEFAULT_OPTIONS,
-    });
-  }
-
   function LoadedInteractiveProviders({ children }: { children: React.ReactNode }) {
-    const [queryClient] = useState(createPharosQueryClient);
     const { toasts, addToast, removeToast } = toastHook.useToast();
     const { toggleTheme } = themeHook.useThemeToggle({ toast: addToast });
     const [commandPaletteLoaded, setCommandPaletteLoaded] = useState(false);
@@ -150,27 +142,25 @@ const InteractiveProviders = lazy(async () => {
     }, [openGlobalCommandPalette, toggleTheme]);
 
     return (
-      <query.QueryClientProvider client={queryClient}>
-        <ToastContext.Provider value={{ addToast }}>
-          <routeProgress.RouteProgressBar />
-          {children}
-          {commandPaletteLoaded && (
-            <Suspense fallback={null}>
-              <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
-            </Suspense>
-          )}
-          {keyboardShortcutsLoaded && (
-            <Suspense fallback={null}>
-              <KeyboardShortcuts open={keyboardShortcutsOpen} onOpenChange={setKeyboardShortcutsOpen} />
-            </Suspense>
-          )}
-          {toasts.length > 0 && (
-            <Suspense fallback={null}>
-              <ToastContainer toasts={toasts} removeToast={removeToast} />
-            </Suspense>
-          )}
-        </ToastContext.Provider>
-      </query.QueryClientProvider>
+      <ToastContext.Provider value={{ addToast }}>
+        <routeProgress.RouteProgressBar />
+        {children}
+        {commandPaletteLoaded && (
+          <Suspense fallback={null}>
+            <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
+          </Suspense>
+        )}
+        {keyboardShortcutsLoaded && (
+          <Suspense fallback={null}>
+            <KeyboardShortcuts open={keyboardShortcutsOpen} onOpenChange={setKeyboardShortcutsOpen} />
+          </Suspense>
+        )}
+        {toasts.length > 0 && (
+          <Suspense fallback={null}>
+            <ToastContainer toasts={toasts} removeToast={removeToast} />
+          </Suspense>
+        )}
+      </ToastContext.Provider>
     );
   }
 
@@ -183,13 +173,21 @@ function RouteProviders({ children }: { children: React.ReactNode }) {
   return <InteractiveProviders>{children}</InteractiveProviders>;
 }
 
-/** Theme is the immutable shell; data and global interactions load only on interactive routes. */
+/**
+ * Theme and the query client are the immutable shell: the global chrome
+ * (TopNav health menu, RegimeBar PSI) queries on every route, including static
+ * content routes, so the provider cannot be route-gated. Overlays, shortcuts,
+ * toasts, and the route progress bar load only on interactive routes.
+ */
 export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient({ defaultOptions: PHAROS_QUERY_DEFAULT_OPTIONS }));
   return (
     <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-      <Suspense fallback={null}>
-        <RouteProviders>{children}</RouteProviders>
-      </Suspense>
+      <QueryClientProvider client={queryClient}>
+        <Suspense fallback={null}>
+          <RouteProviders>{children}</RouteProviders>
+        </Suspense>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
Follow-up to #1023. The Pages release in deploy run 33789773169 failed prerendering `/about` ("No QueryClient set"): 7.3 route-gated `QueryClientProvider` off static content routes while the global chrome (TopNav health menu, RegimeBar PSI) queries on every route. The query client moves into the immutable shell; the lazy interactive layer still gates overlays, shortcuts, toasts, and the route progress bar. Verified locally with a full `next build --webpack` (1,326 pages).