### PR TITLE
fix(seo): lengthen depeg archive title

### DIFF
--- a/src/app/depeg/archive/page.tsx
+++ b/src/app/depeg/archive/page.tsx
@@ -7,7 +7,7 @@ const ARCHIVE_DESCRIPTION =
   "Browse every permanent Pharos depeg event page, grouped by month with dates, peak deviations, and links to the complete incident record.";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "Depeg Event Archive",
+  title: "Stablecoin Depeg Event Archive | Pharos",
   description: ARCHIVE_DESCRIPTION,
   canonical: "/depeg/archive/",
 });

--- a/src/app/depeg/page.test.tsx
+++ b/src/app/depeg/page.test.tsx
@@ -75,7 +75,7 @@ describe("DepegArchivePage", () => {
 
   it("publishes canonical archive metadata", () => {
     expect(archiveMetadata.alternates?.canonical).toBe("/depeg/archive/");
-    expect(archiveMetadata.title).toBe("Depeg Event Archive");
+    expect(archiveMetadata.title).toBe("Stablecoin Depeg Event Archive | Pharos");
     expect(archiveMetadata.description).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- lengthen the depeg archive metadata title to satisfy the production SEO minimum
- keep the visible archive heading unchanged

## Verification

- npx vitest run src/app/depeg
- npm run typecheck
- npm run check:pr -- --base=origin/main