### PR TITLE
Fix deep-link hydration after SEO release acceptance

### DIFF
--- a/docs/alt-pegs-page.md
+++ b/docs/alt-pegs-page.md
@@ -42,6 +42,7 @@ Focused chart inspection stays on the same route through query-param state:
 
 The canonical route remains `/alt-pegs/`; focused query states are shareable inspection views, not separate canonical pages.
 On the share chart, `range=all` means all currently loaded points from the `non-usd-share` endpoint window rather than unbounded history.
+Closing a focused chart retains its selected range in the overview, including when the focused view was opened from a deep link after hydration.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,7 @@ Worker cron refactors should place reusable stage helpers under `worker/src/cron
 
 ### Runtime host and env rules
 
+- `src/hooks/use-url-filters.ts` subscribes to browser history through React's external-store API. Static HTML and first hydration use a query-free snapshot; `isReady` distinguishes that phase from a genuinely empty browser query. URL normalization and one-time consumer initialization must wait for readiness. Filter writes preserve the current hash, and push/replace/popstate keep consumers synchronized.
 - `src/lib/api-url.ts` is the frontend runtime source of truth for API origin selection; `src/lib/api.ts` re-exports those helpers and layers request/freshness handling on top.
 - `src/lib/request.ts` owns bespoke frontend JSON, text, blob, and raw-response lifecycles outside the endpoint-query registry. Its timeout covers response-body consumption, caller and timeout signals are merged, failures are classified, and `RequestSequence` cancels superseded UI requests and rejects late completions. TanStack endpoint reads continue through `src/lib/api.ts` and `useRegisteredApiQuery()`, with the query signal forwarded to the transport.
 - `NEXT_PUBLIC_API_BASE` is an optional explicit override, mainly for local `next dev` against `wrangler dev`.

--- a/docs/portfolio-page.md
+++ b/docs/portfolio-page.md
@@ -41,6 +41,8 @@ There is no dedicated `/api/portfolio` endpoint. Portfolio holdings stay client-
 
 `usePortfolio` validates canonical holdings only. Unknown or non-canonical IDs are dropped and duplicate canonical IDs are merged. Stored holdings are normalized and written back through `localStorage` after a successful storage-backed read. URL-sourced holdings take precedence and are normalized back into `?p=`, but they are not persisted to `localStorage`.
 
+During static hydration, the shared URL hook's temporary empty snapshot must not override an incoming portfolio link. Portfolio bootstrap falls back to the actual browser URL until that snapshot is ready; rendered holdings and persistence/writeback remain gated by initialization.
+
 ---
 
 ## UI Responsibilities

--- a/docs/screener-picker-page.md
+++ b/docs/screener-picker-page.md
@@ -35,6 +35,8 @@ Changes to ranking, exclusion, missing-data, tie-break, explanation, or determin
 
 Desktop uses a stepwise wizard; browser history walks completed steps. Mobile uses the compact form and a single result commit after required inputs are complete.
 
+The one-time repair of an over-advanced URL step waits for the shared URL snapshot to be ready; the query-free static hydration snapshot must not consume that repair.
+
 Step changes are announced politely and move focus to the active question. Loading states expose `aria-busy`; result generation and snapshot replay move focus to the result summary. Option cards, skipped rows, near misses, relax actions, and result links remain keyboard operable and usable at narrow widths and 200 percent zoom.
 
 Result actions include adjusting answers, verifying the projected filters in `/screener/`, creating a share link, and contextual compare, Telegram, Yield, or per-coin links when the output supports them. `src/lib/selector-handoff.ts` is the authority for the Screener URL and human-readable filter chips. The handoff emits only keys recognized by `SCREENER_URL_SCHEMA`, uses V9-native Backing and Exit names, and includes the recommendation IDs in `coins=`. Constraints the Screener cannot reproduce—yield/source warnings, Bluechip, inherited blacklist exposure, active-depeg, legal uncertainty, and one-hour effective TVL—remain explicit Picker-only divergence chips.

--- a/src/app/alt-pegs/client.test.tsx
+++ b/src/app/alt-pegs/client.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AltPegsClient } from "@/app/alt-pegs/client";
 import { makeStablecoin } from "@shared/test-utils/stablecoin";
@@ -254,6 +256,29 @@ describe("AltPegsClient", () => {
 
     expect(screen.getByText(/share-chart focused 90d/i)).toBeTruthy();
     expect(screen.getByText(/cohort-chart default 1y/i)).toBeTruthy();
+  });
+
+  it("preserves a hydrated focused range when returning to the overview", async () => {
+    window.history.replaceState(null, "", "/alt-pegs/?view=focused&chart=share&range=90d#charts");
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<AltPegsClient />);
+    document.body.append(container);
+    const errors: unknown[] = [];
+    let root: ReturnType<typeof hydrateRoot>;
+    await act(async () => {
+      root = hydrateRoot(container, <AltPegsClient />, { onRecoverableError: (error) => errors.push(error) });
+    });
+    try {
+      expect(screen.getByText(/share-chart focused 90d/i)).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "close-share" }));
+      await waitFor(() => expect(screen.getByText(/share-chart default 90d/i)).toBeTruthy());
+      expectFocusSearch({});
+      expect(window.location.hash).toBe("#charts");
+      expect(errors).toEqual([]);
+    } finally {
+      act(() => root!.unmount());
+      container.remove();
+    }
   });
 
   it("opens and updates a focused share chart through URL state", async () => {

--- a/src/app/alt-pegs/client.tsx
+++ b/src/app/alt-pegs/client.tsx
@@ -240,12 +240,14 @@ export function AltPegsClient() {
   );
 
   const closeFocusedChart = useCallback(() => {
+    if (focusedChart === "share") setShareRange(focusedRange);
+    if (focusedChart === "cohorts") setCohortRange(focusedRange);
     replaceParams((params) => {
       params.delete("view");
       params.delete("chart");
       params.delete("range");
     });
-  }, [replaceParams]);
+  }, [focusedChart, focusedRange, replaceParams]);
 
   const setFocusedRange = useCallback(
     (chart: FocusedChart, range: TimeRangeOption) => {

--- a/src/app/portfolio/client.tsx
+++ b/src/app/portfolio/client.tsx
@@ -43,11 +43,10 @@ export function PortfolioClient() {
   const [toast, setToast] = useState<string | null>(null);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
-  // URL sync: keep query string in sync with portfolio holdings. The router-
-  // aware initial `p` param seeds the portfolio so a shared/soft-navigated URL
-  // restores state without reading window.location inside the hook.
-  const { getParam, setParam } = useUrlFilters();
-  const portfolio = usePortfolio(getParam("p"));
+  // Wait for the browser URL snapshot before exposing or writing holdings;
+  // the portfolio bootstrap preserves incoming shares during hydration.
+  const { getParam, isReady, setParam } = useUrlFilters();
+  const portfolio = usePortfolio(getParam("p"), isReady);
 
   // Clean up toast timer on unmount
   useEffect(() => () => { if (toastTimerRef.current) clearTimeout(toastTimerRef.current); }, []);

--- a/src/hooks/__tests__/use-url-filters-hydration.test.tsx
+++ b/src/hooks/__tests__/use-url-filters-hydration.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, waitFor } from "@testing-library/react";
+import { createElement, useEffect } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUrlFilters } from "../use-url-filters";
+import { useCompareSelection } from "../use-compare-selection";
+import { useSelectorState } from "../use-selector-state";
+import { usePortfolio } from "../use-portfolio";
+import { encodePortfolioHoldings } from "@/lib/portfolio-codec";
+
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+const roots: Root[] = [];
+beforeEach(() => {
+  window.history.replaceState(null, "", "/");
+  window.localStorage.clear();
+});
+afterEach(() => {
+  act(() => { for (const root of roots.splice(0)) root.unmount(); });
+  cleanup();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+async function hydrate(Probe: () => ReturnType<typeof createElement>) {
+  const container = document.createElement("div");
+  container.innerHTML = renderToString(createElement(Probe));
+  document.body.append(container);
+  const serverText = container.textContent;
+  const errors: unknown[] = [];
+  await act(async () => {
+    roots.push(hydrateRoot(container, createElement(Probe), { onRecoverableError: (error) => errors.push(error) }));
+  });
+  return { container, serverText, errors };
+}
+
+describe("URL-filter hydration", () => {
+  it("uses a deterministic first snapshot then restores query and history without losing the fragment", async () => {
+    window.history.replaceState(null, "", "/compare/?coins=usdc-circle&scope=all#data");
+    function Probe() {
+      const { getParam, isReady, setParam } = useUrlFilters();
+      return createElement("button", { onClick: () => setParam("coins", "usdt-tether") }, `${isReady}:${getParam("coins")}`);
+    }
+    const { container, serverText, errors } = await hydrate(Probe);
+    expect(serverText).toBe("false:");
+    expect(container.textContent).toBe("true:usdc-circle");
+    expect(errors).toEqual([]);
+    await act(async () => { container.querySelector("button")!.click(); });
+    expect(window.location.search).toBe("?coins=usdt-tether&scope=all");
+    expect(window.location.hash).toBe("#data");
+    expect(container.textContent).toBe("true:usdt-tether");
+    await act(async () => {
+      window.history.pushState(null, "", "/compare/?coins=usdc-circle#data");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(container.textContent).toBe("true:usdc-circle");
+  });
+
+  it("hydrates real comparison selection before normalizing duplicate IDs", async () => {
+    window.history.replaceState(null, "", "/compare/?coins=usdc-circle,usdc-circle&scope=all#data");
+    function Probe() {
+      const { selectedIds } = useCompareSelection();
+      return createElement("p", null, selectedIds.join(",") || "No selected coins");
+    }
+    const { container, serverText, errors } = await hydrate(Probe);
+    expect(serverText).toBe("No selected coins");
+    await waitFor(() => expect(container.textContent).toBe("usdc-circle"));
+    expect(errors).toEqual([]);
+    expect(window.location.search).toBe("?coins=usdc-circle&scope=all");
+    expect(window.location.hash).toBe("#data");
+  });
+
+  it("waits for the real Selector state before consuming its one-time repair", async () => {
+    window.history.replaceState(null, "", "/screener/picker/?scope=all&p=treasury&step=result#result");
+    function Probe() {
+      const { state } = useSelectorState();
+      return createElement("p", null, `${state.profile}:${state.step}`);
+    }
+    const { container, errors } = await hydrate(Probe);
+    await waitFor(() => expect(container.textContent).toBe("treasury:3"));
+    expect(errors).toEqual([]);
+    expect(window.location.search).toBe("?scope=all&p=treasury&step=3");
+    expect(window.location.hash).toBe("#result");
+  });
+
+  it("restores a shared portfolio without publishing or persisting conflicting local holdings", async () => {
+    const saved = JSON.stringify([{ coinId: "usdt-tether", amount: 50 }]);
+    window.localStorage.setItem("pharos:portfolio", saved);
+    window.history.replaceState(null, "", "/portfolio/?p=usdc-circle:20&scope=all#holdings");
+    const storageWrite = vi.spyOn(Storage.prototype, "setItem");
+    function Probe() {
+      const { getParam, isReady, setParam } = useUrlFilters();
+      const portfolio = usePortfolio(getParam("p"), isReady);
+      useEffect(() => {
+        if (portfolio.initialized) setParam("p", encodePortfolioHoldings(portfolio.holdings));
+      }, [portfolio.initialized, portfolio.holdings, setParam]);
+      return createElement("p", null, JSON.stringify({ initialized: portfolio.initialized, fromUrl: portfolio.isFromUrl, holdings: portfolio.holdings, total: portfolio.totalUsd }));
+    }
+    const { container, serverText, errors } = await hydrate(Probe);
+    expect(JSON.parse(serverText!)).toEqual({ initialized: false, fromUrl: false, holdings: [], total: 0 });
+    await waitFor(() => expect(JSON.parse(container.textContent!).holdings).toEqual([{ coinId: "usdc-circle", amount: 20 }]));
+    expect(errors).toEqual([]);
+    expect(JSON.parse(container.textContent!)).toMatchObject({ initialized: true, fromUrl: true, total: 20 });
+    expect(new URLSearchParams(window.location.search).get("p")).toBe("usdc-circle:20");
+    expect(new URLSearchParams(window.location.search).get("scope")).toBe("all");
+    expect(window.location.hash).toBe("#holdings");
+    expect(window.localStorage.getItem("pharos:portfolio")).toBe(saved);
+    expect(storageWrite).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-portfolio.ts
+++ b/src/hooks/use-portfolio.ts
@@ -85,11 +85,13 @@ function getInitialPortfolioState(initialUrlParam?: string): {
 
 export function usePortfolio(
   initialUrlParam?: string,
+  urlReady = true,
 ): PortfolioState {
-  const [bootState] = useState(() => getInitialPortfolioState(initialUrlParam));
+  // During hydration the caller has a server snapshot, not an empty shared URL.
+  const [bootState] = useState(() => getInitialPortfolioState(urlReady ? initialUrlParam : undefined));
   const [holdings, setHoldings] = useState<PortfolioHolding[]>(bootState.holdings);
   const [isFromUrl] = useState(bootState.isFromUrl);
-  const initialized = bootState.initialized;
+  const initialized = bootState.initialized && urlReady;
 
   // Persist to localStorage when holdings change (only if NOT from URL)
   useEffect(() => {
@@ -149,9 +151,9 @@ export function usePortfolio(
 
   return {
     initialized,
-    holdings,
-    totalUsd,
-    isFromUrl,
+    holdings: initialized ? holdings : [],
+    totalUsd: initialized ? totalUsd : 0,
+    isFromUrl: initialized && isFromUrl,
     addCoin,
     removeCoin,
     setAmount,

--- a/src/hooks/use-selector-state.ts
+++ b/src/hooks/use-selector-state.ts
@@ -24,12 +24,12 @@ function writeSelectorState(params: URLSearchParams, state: SelectorWizardState)
 }
 
 export function useSelectorState(): UseSelectorStateResult {
-  const { searchParams, pushSearchParams, replaceParams } = useUrlFilters();
+  const { searchParams, isReady, pushSearchParams, replaceParams } = useUrlFilters();
   const state = useMemo(() => decodeSelectorState(searchParams), [searchParams]);
   const rehydratedRef = useRef(false);
 
   useEffect(() => {
-    if (rehydratedRef.current) return;
+    if (!isReady || rehydratedRef.current) return;
     rehydratedRef.current = true;
     const valid = highestValidStep(state);
     const urlStep = state.step;
@@ -40,7 +40,7 @@ export function useSelectorState(): UseSelectorStateResult {
       const next = { ...state, step: valid };
       replaceParams((params) => writeSelectorState(params, next));
     }
-  }, [state, replaceParams]);
+  }, [isReady, state, replaceParams]);
 
   const dispatch = useCallback((action: SelectorAction) => {
     const next = transition(state, action);

--- a/src/hooks/use-url-filters.ts
+++ b/src/hooks/use-url-filters.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 
 /**
  * Shared hook for managing URL search-param-based filters.
@@ -78,38 +78,24 @@ export function isUrlFilterClearValue(value: string): boolean {
   return value === "all" || value === "";
 }
 
+function subscribeToUrlChanges(listener: () => void): () => void {
+  window.addEventListener("popstate", listener);
+  const unsubscribe = subscribeToHistoryChanges(listener);
+  return () => {
+    window.removeEventListener("popstate", listener);
+    unsubscribe();
+  };
+}
+
+const getSearchSnapshot = () => window.location.search;
+const getServerSearchSnapshot = () => null;
+
 export function useUrlFilters() {
-  const [search, setSearch] = useState(() => (
-    typeof window !== "undefined" ? window.location.search : ""
-  ));
-
-  // syncFromLocation is referentially stable (empty useCallback deps) —
-  // safe to use as a useEffect dependency without causing re-subscription loops.
-  const syncFromLocation = useCallback(() => {
-    if (typeof window === "undefined") return;
-    setSearch(window.location.search);
-  }, []);
-
-  useEffect(() => {
-    let active = true;
-    window.addEventListener("popstate", syncFromLocation);
-    const unsubscribeFromHistoryChanges = subscribeToHistoryChanges(syncFromLocation);
-    const syncAfterCommit = () => {
-      if (active) syncFromLocation();
-    };
-    if (typeof window.queueMicrotask === "function") {
-      window.queueMicrotask(syncAfterCommit);
-    } else {
-      window.setTimeout(syncAfterCommit, 0);
-    }
-    return () => {
-      active = false;
-      window.removeEventListener("popstate", syncFromLocation);
-      unsubscribeFromHistoryChanges();
-    };
-  }, [syncFromLocation]);
-
-  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
+  // Static HTML and its first hydration render cannot know the browser query.
+  // null distinguishes that phase from a ready URL with no search parameters.
+  const search = useSyncExternalStore(subscribeToUrlChanges, getSearchSnapshot, getServerSearchSnapshot);
+  const isReady = search !== null;
+  const searchParams = useMemo(() => new URLSearchParams(search ?? ""), [search]);
 
   const getParam = useCallback(
     (key: string, defaultValue = ""): string => {
@@ -122,7 +108,7 @@ export function useUrlFilters() {
     if (typeof window === "undefined") return;
     const qs = params.toString();
     const nextSearch = qs ? `?${qs}` : "";
-    const nextUrl = `${window.location.pathname}${nextSearch}`;
+    const nextUrl = `${window.location.pathname}${nextSearch}${window.location.hash}`;
     if (window.location.search !== nextSearch) {
       if (mode === "push") {
         window.history.pushState(null, "", nextUrl);
@@ -130,7 +116,9 @@ export function useUrlFilters() {
         window.history.replaceState(null, "", nextUrl);
       }
     }
-    setSearch(nextSearch);
+    // Hook-owned writes retain immediate state updates; unrelated history
+    // wrappers still notify in a microtask to avoid render-phase updates.
+    window.dispatchEvent(new Event(URL_FILTER_HISTORY_CHANGE_EVENT));
   }, []);
 
   const setParam = useCallback(
@@ -179,5 +167,5 @@ export function useUrlFilters() {
     [searchParams, writeParams],
   );
 
-  return { searchParams, getParam, setParam, setParams, pushSearchParams, replaceParams };
+  return { searchParams, isReady, getParam, setParam, setParams, pushSearchParams, replaceParams };
 }

--- a/src/hooks/use-url-state.ts
+++ b/src/hooks/use-url-state.ts
@@ -12,7 +12,7 @@ type UseUrlStateOptions<T> = {
 };
 
 export function useUrlState<T>(schema: UrlStateSchema<T>, options?: UseUrlStateOptions<T>) {
-  const { searchParams, replaceParams } = useUrlFilters();
+  const { searchParams, isReady, replaceParams } = useUrlFilters();
   const enabled = options?.enabled;
   const fallback = options?.fallback;
   const clear = options?.clear;
@@ -35,14 +35,14 @@ export function useUrlState<T>(schema: UrlStateSchema<T>, options?: UseUrlStateO
   );
 
   useEffect(() => {
-    if (!normalizeKey || enabled === false) return;
+    if (!isReady || !normalizeKey || enabled === false) return;
     const value = new URLSearchParams(encodeState(state, schema)).get(normalizeKey);
     if (searchParams.get(normalizeKey) === value) return;
     replaceParams((params) => {
       if (value === null) params.delete(normalizeKey);
       else params.set(normalizeKey, value);
     });
-  }, [enabled, normalizeKey, replaceParams, schema, searchParams, state]);
+  }, [enabled, isReady, normalizeKey, replaceParams, schema, searchParams, state]);
 
   return { state, replaceState, patchState, searchParams };
 }


### PR DESCRIPTION
## Why

Post-deployment acceptance of #1044 reproduced React hydration errors on query-bearing comparison links. The shared URL hook read browser queries before hydration against query-free static HTML.

## Change

- Replace manual URL-state synchronization with React's external-store snapshot.
- Defer normalization and Selector repair until URL readiness.
- Preserve URL portfolio priority over saved holdings, focused chart ranges, and fragments.
- Add actual SSR-to-hydration regressions and update owning docs.

## Verification

- 34 focused tests across 7 files passed; explicit changed-file ESLint and frontend typecheck passed.
- Independent caller/state-loss review found no blocker.
- Committed-range local check:pr rehearsal passed: 907 tests across 67 files plus selected static checks; GitHub PR gate remains authoritative.
- Pages-only deployment; no Worker, migration, cron, methodology, or source-data changes.

Plan: agents/2026-09-06-seo-release/README.md
Tasks: R3, R6
