### PR TITLE
fix(flows): reclassify cached FTQ on safety publication changes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -857,6 +857,8 @@ Returns bounded yield history for one stablecoin and optional source projection.
 
 Returns aggregate mint and burn pressure over the requested window.
 
+When the current Safety Score publication differs from the cached aggregate's identity, the handler recomputes flight-to-quality from the cached per-coin 24-hour net flows and current cohorts. Flow timestamps and freshness headers remain unchanged. Unusable classification sources or invalid cached coin inputs retain the fail-closed FTQ state and warning.
+
 - **Operation ID:** `mintBurnFlows`
 - **Path:** `/api/mint-burn-flows`
 - **Parameters:** `stablecoin` (query, optional, string); `hours` (query, optional, integer)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -345,10 +345,6 @@ Returns the current stablecoin catalogue, prices, supply, chain breakdowns, and 
 
 Returns the full current and historical detail payload for one canonical Pharos stablecoin ID.
 
-For active records, a missing or invalid top-level `price` is enriched from the validated current stablecoins publication when both that publication and its positive price observation are fresh. Enrichment requires `high` or `single-source` confidence and a non-cached source; missing, withheld, stale, or frozen observations leave the provider response unchanged. An existing finite positive provider price is preserved. Retained inactive-record detail is never enriched.
-
-An enriched response includes `priceSource`, `priceConfidence`, `priceUpdatedAt`, `priceObservedAt`, `priceObservedAtMode`, `priceSyncedAt`, `consensusSources`, and `agreeSources`, plus `priceSourceConfidenceProfile` when available. Observation timestamps retain their pricing provenance; the response does not substitute request time or history time. Browser/edge cache lifetimes are capped by the remaining canonical publication and observation freshness windows. Historical `tokens`, supply values, retained detail cache rows, and stale-history `Warning` / `X-Data-Age` / `no-store` semantics are unchanged.
-
 - **Operation ID:** `stablecoinStablecoinId`
 - **Path:** `/api/stablecoin/{stablecoinId}`
 - **Parameters:** `stablecoinId` (path, required, string)
@@ -856,8 +852,6 @@ Returns bounded yield history for one stablecoin and optional source projection.
 ### `GET /api/mint-burn-flows`
 
 Returns aggregate mint and burn pressure over the requested window.
-
-When the current Safety Score publication differs from the cached aggregate's identity, the handler recomputes flight-to-quality from the cached per-coin 24-hour net flows and current cohorts. Flow timestamps and freshness headers remain unchanged. Unusable classification sources or invalid cached coin inputs retain the fail-closed FTQ state and warning.
 
 - **Operation ID:** `mintBurnFlows`
 - **Path:** `/api/mint-burn-flows`

--- a/docs/mint-burn-flows.md
+++ b/docs/mint-burn-flows.md
@@ -312,6 +312,7 @@ Detects simultaneous outflows from risky stablecoins and inflows to safe havens.
 - **Activation:** `riskyNet24h < -$100M` AND `safeNet24h > +$100M`
 - **Intensity:** `min(100, |riskyNet24h| / $1B * 100)`
 - Safe/risky cohorts come from the report-card cache: `B-` or better is safe, `C+` through `C-` is neutral, and grades below `C-` are risky. If the complete identified report-card cache is unavailable, flight-to-quality classification is unavailable rather than falling back to hardcoded safe havens.
+- On aggregate API reads, a changed publication identity triggers FTQ recomputation from the validated cached per-coin `netFlow24hUsd` values and current cohorts. This updates only the response's FTQ fields, classification identity, and classification warning; the cached flow data, producer timestamps, freshness headers, and database row are preserved. Missing, held, stale, or malformed Safety Score sources and invalid cached coin inputs still fail closed.
 
 ---
 

--- a/worker/src/api/__tests__/mint-burn-flows.test.ts
+++ b/worker/src/api/__tests__/mint-burn-flows.test.ts
@@ -509,8 +509,15 @@ describe("handleMintBurnFlows contract tests", () => {
     expect(db.getHistory().some((entry) => entry.binds.includes("report_card_cache"))).toBe(false);
   });
 
-  it("removes cached FTQ output when its report-card identity is no longer active", async () => {
+  it.each([
+    { safeNet: 200_000_000, invalid: false, sourceUnavailable: false, stale: false, hours: 24, expectedIntensity: 40 },
+    { safeNet: -200_000_000, invalid: false, sourceUnavailable: false, stale: true, hours: 168, expectedIntensity: 0 },
+    { safeNet: 200_000_000, invalid: true, sourceUnavailable: false, stale: false, hours: 24, expectedIntensity: 0 },
+    { safeNet: 200_000_000, invalid: false, sourceUnavailable: true, stale: false, hours: 24, expectedIntensity: 0 },
+  ])("reconciles a newer FTQ publication using cached flows: %j", async ({ safeNet, invalid, sourceUnavailable, stale, hours, expectedIntensity }) => {
     const now = Math.floor(Date.now() / 1000);
+    vi.useFakeTimers();
+    vi.setSystemTime(now * 1000);
     const cachedGenerationId = `report-cards:v9:${now - 900}`;
     const activeGenerationId = `report-cards:v9:${now}`;
     const cachedIdentity = {
@@ -542,19 +549,47 @@ describe("handleMintBurnFlows contract tests", () => {
     vi.spyOn(
       flightToQualityClassification,
       "buildFlightToQualityClassificationFromV9Snapshot",
-    ).mockReturnValueOnce({
+    ).mockReturnValueOnce(sourceUnavailable ? { kind: "unavailable", reason: "publication-held" } : {
       kind: "ok",
       classification: {
         safeIds: new Set(["usdc-circle"]),
-        riskyIds: new Set(),
+        riskyIds: new Set(["usdai-usd-ai"]),
         safetyScoreIdentity: activeSnapshot.safetyScoreIdentity,
       },
     });
-    const cachedBody = makeValidCachedAggregateFixture(now, cachedIdentity);
+    const cachedBody = {
+      ...makeValidCachedAggregateFixture(stale ? now - 86400 : now, cachedIdentity),
+      windowHours: hours,
+      coins: [
+        ["usdc-circle", safeNet],
+        ["usdai-usd-ai", -400_000_000],
+        ["dai-makerdao", -1_000_000_000], // Neutral flows must not contribute to FTQ.
+      ].map(([stablecoinId, netFlow24hUsd]) => ({
+        stablecoinId,
+        symbol: "TEST",
+        netFlow24hUsd: invalid ? null : netFlow24hUsd,
+        flowIntensity: null,
+        pressureShiftScore: null,
+        pressureShiftState: "nr",
+        netFlowDirection24h: "flat",
+        has24hActivity: true,
+        baselineDailyNetUsd: null,
+        baselineDailyAbsUsd: null,
+        baselineDataDays: null,
+        mintVolume24hUsd: 0,
+        burnVolume24hUsd: 0,
+        mintCount24h: 0,
+        burnCount24h: 0,
+        netFlow7dUsd: 0,
+        netFlow30dUsd: 0,
+        netFlow90dUsd: 0,
+        largestEvent24h: null,
+      })),
+    };
     const db = mintBurnScenario({
       nowSec: now,
       flowCache: {
-        key: "mint-burn-flows:v3:aggregate:24",
+        key: `mint-burn-flows:v3:aggregate:${hours}`,
         value: JSON.stringify(cachedBody),
         updatedAt: now,
       },
@@ -565,17 +600,37 @@ describe("handleMintBurnFlows contract tests", () => {
       }],
     });
 
-    const res = await handleMintBurnFlows(db, new URL("https://x/api/mint-burn-flows"));
-    const body = MintBurnFlowsResponseSchema.parse(await res.json());
+    const res = await handleMintBurnFlows(db, new URL(`https://x/api/mint-burn-flows?hours=${hours}`));
+    const body = await readJsonResponse<typeof cachedBody>(res, 200);
+    if (!invalid) MintBurnFlowsResponseSchema.parse(body);
 
+    const unavailable = invalid || sourceUnavailable;
     expect(body.gauge).toMatchObject({
-      flightToQuality: false,
-      flightIntensity: 0,
-      classificationSource: "unavailable",
-      safetyScoreIdentity: null,
+      score: cachedBody.gauge.score,
+      flightToQuality: expectedIntensity > 0,
+      flightIntensity: expectedIntensity,
+      classificationSource: unavailable ? "unavailable" : "safety-score-v9-publication",
+      safetyScoreIdentity: unavailable ? null : activeSnapshot.safetyScoreIdentity,
     });
-    expect(body.sync?.classificationWarning).toContain("identity-mismatch");
+    if (unavailable) {
+      const reason = sourceUnavailable ? "publication-held" : "identity-mismatch";
+      expect(body.sync?.classificationWarning).toContain(reason);
+      expect(res.headers.get("Warning")).toContain(reason);
+    } else {
+      expect(body.sync).toEqual(cachedBody.sync);
+      if (stale) {
+        expect(res.headers.get("Warning")).toContain('110 - "Response is stale');
+        expect(res.headers.get("Cache-Control")).toBe("no-store");
+      } else {
+        expect(res.headers.get("Warning")).toBeNull();
+      }
+    }
+    expect(body.coins).toEqual(cachedBody.coins);
+    expect(body.hourly).toEqual(cachedBody.hourly);
+    expect(body.updatedAt).toBe(cachedBody.updatedAt);
+    expect(res.headers.get("X-Data-Age")).toBe(String(now - cachedBody.sync.lastSuccessfulSyncAt));
     expect(db.getHistory().some((entry) => entry.sql.includes("FROM mint_burn_hourly"))).toBe(false);
+    expect(db.getHistory().some((entry) => /INSERT|UPDATE|DELETE/.test(entry.sql))).toBe(false);
   });
 
   it("keeps cached aggregate flow data while disabling FTQ when report-card validation throws", async () => {

--- a/worker/src/api/mint-burn-flows.ts
+++ b/worker/src/api/mint-burn-flows.ts
@@ -8,6 +8,7 @@ import { buildMintBurnSyncHealth } from "../lib/mint-burn-health-config";
 import { computeGaugeScore, detectFlightToQuality, getGaugeBand } from "../lib/mint-burn-scoring";
 import { loadStablecoinsCache } from "../lib/stablecoins-cache";
 import type { StablecoinData } from "@shared/types/market";
+import { MintBurnFlowsResponseSchema } from "@shared/types/mint-burn";
 import { sumMcapForTrackedChains } from "../lib/mint-burn-mcap-weighting";
 import {
   buildFlightToQualityClassificationFromV9Snapshot,
@@ -212,7 +213,8 @@ function cachedAggregateSafetyIdentity(payload: Record<string, unknown>): Safety
 /**
  * Aggregate flow cache rows retain their FTQ cohort identity. A cache may be
  * served for flow freshness, but never with an FTQ decision from another
- * report-card publication.
+ * report-card publication. Reclassify cached 24h flows when that publication
+ * advances; this does not refresh the underlying flow snapshot.
  */
 async function reconcileCachedAggregateSafetyResponse(
   db: D1Database,
@@ -248,6 +250,34 @@ async function reconcileCachedAggregateSafetyResponse(
                   )
                 ? null
                 : "identity-mismatch";
+          if (reason === "identity-mismatch" && current.kind === "ok") {
+            const coins = MintBurnFlowsResponseSchema.shape.coins.safeParse(payload.coins);
+            if (coins.success) {
+              let safeNet24h = 0;
+              let riskyNet24h = 0;
+              for (const coin of coins.data) {
+                if (current.classification.safeIds.has(coin.stablecoinId)) {
+                  safeNet24h += coin.netFlow24hUsd;
+                } else if (current.classification.riskyIds.has(coin.stablecoinId)) {
+                  riskyNet24h += coin.netFlow24hUsd;
+                }
+              }
+              const ftq = detectFlightToQuality({ safeNet24h, riskyNet24h });
+              return cloneResponse(fallback, {
+                body: JSON.stringify({
+                  ...payload,
+                  gauge: {
+                    ...(isRecord(payload.gauge) ? payload.gauge : {}),
+                    flightToQuality: ftq.active,
+                    flightIntensity: ftq.intensity,
+                    classificationSource: "safety-score-v9-publication",
+                    safetyScoreIdentity: current.classification.safetyScoreIdentity,
+                  },
+                  ...(isRecord(payload.sync) ? { sync: { ...payload.sync, classificationWarning: null } } : {}),
+                }),
+              });
+            }
+          }
       } else {
         reason = active.kind === "error" ? active.reason : "identity-mismatch";
       }


### PR DESCRIPTION
## Problem
A newer Safety Score publication could make a healthy cached mint/burn aggregate emit an identity-mismatch warning and lose its FTQ classification.

## Change
Recompute FTQ from validated cached 24-hour net flows and the current cohorts when the publication advances, while preserving the cached flow timestamps, freshness metadata, and fail-closed behavior. Add coverage for active, cleared, invalid, held, and stale cases, plus the generated API reference refresh.

## Validation
- `npm run check:focused -- --file worker/src/api/mint-burn-flows.ts --file worker/src/api/__tests__/mint-burn-flows.test.ts --file docs/api-reference.md --file docs/mint-burn-flows.md`
- `npm run check:generated-artifacts`
- `npm run check:pr -- --base=origin/main` (40 test files, 709 tests)
