### PR TITLE
Record approved Base USDC donation and release the eligibility ledger

### DIFF
--- a/docs/funding-page.md
+++ b/docs/funding-page.md
@@ -47,6 +47,8 @@ The page advertises the perk in two places: a `Supporter API key` note inside th
 
 ## Ownership & cadence
 
+Donation-ledger changes select both Worker and Pages deployment through `scripts/lib/automation-registry.mjs`: the Worker embeds the eligibility ledger, while Pages publishes the funding view. Cost-only edits remain Pages-only.
+
 - `costs.json` — target review date is the 1st of each month; if it is missed, leave the stale `last_reviewed_at` visible and complete the review before describing costs as current. Bump the timestamp every time you edit.
 - `donations.json` — `funding-update` skill invoked ~weekly, or ad-hoc on alert. `last_updated_at` is bumped automatically by the skill.
 

--- a/scripts/__tests__/classify-deploy-changes.test.ts
+++ b/scripts/__tests__/classify-deploy-changes.test.ts
@@ -47,7 +47,7 @@ describe("hasWorkerDeployImpact", () => {
       "shared/lib/pharosville-api-contract.ts",
       "shared/types/pharosville.ts",
       "shared/lib/selector/engine.ts",
-      "shared/data/funding/donations.json",
+      "shared/data/funding/costs.json",
     ];
 
     for (const file of pagesOnlySharedFiles) {
@@ -145,7 +145,16 @@ describe("hasWorkerReleaseImpact", () => {
     expect(hasWorkerReleaseImpact(["shared/lib/pharosville-api-contract.ts"])).toBe(false);
     expect(hasWorkerReleaseImpact(["shared/types/pharosville.ts"])).toBe(false);
     expect(hasWorkerReleaseImpact(["shared/lib/selector/engine.ts"])).toBe(false);
-    expect(hasWorkerReleaseImpact(["shared/data/funding/donations.json"])).toBe(false);
+    expect(hasWorkerReleaseImpact(["shared/data/funding/costs.json"])).toBe(false);
+  });
+
+  it("releases both surfaces for the donation ledger consumed by supporter claims", () => {
+    expect(classifyChangedFiles(["shared/data/funding/donations.json"])).toMatchObject({
+      workerChanged: true,
+      workerDeployRequired: true,
+      pagesChanged: true,
+      pagesDeployRequired: true,
+    });
   });
 });
 

--- a/scripts/lib/automation-registry.mjs
+++ b/scripts/lib/automation-registry.mjs
@@ -47,7 +47,7 @@ export const DEPLOY_IMPACT_REGISTRY = {
     workflowOnlyExactPaths: [".github/workflows/pages-release.yml", ".github/workflows/rebuild-pages.yml"],
   },
   worker: {
-    exactPaths: [],
+    exactPaths: ["shared/data/funding/donations.json"],
     prefixes: ["worker/"],
     sharedExcludedPaths: [
       "shared/lib/pharosville-api-contract.ts",
@@ -62,6 +62,7 @@ export const DEPLOY_IMPACT_REGISTRY = {
     exactPaths: [
       "package-lock.json",
       "package.json",
+      "shared/data/funding/donations.json",
       "worker/package.json",
       "worker/tsconfig.json",
       "worker/wrangler.toml",

--- a/shared/data/funding/donations.json
+++ b/shared/data/funding/donations.json
@@ -1,5 +1,5 @@
 {
-  "last_updated_at": 1788681300,
+  "last_updated_at": 1788798832,
   "donations": [
     {
       "chain": "ethereum",
@@ -743,6 +743,18 @@
       "asset_symbol": "USDC",
       "amount_decimal": 10,
       "usd_at_receipt": 10,
+      "price_note": "stablecoin-1-to-1"
+    },
+    {
+      "chain": "base",
+      "tx_hash": "0xa4cc5b5d137afa130a92624e8a1073e03167c9445283b64a5580a870526ab033",
+      "block_timestamp": 1788798569,
+      "from_address": "0xaa7a9d80971e58641442774c373c94aafee87d66",
+      "display": "tokenbrice.eth",
+      "kind": "community",
+      "asset_symbol": "USDC",
+      "amount_decimal": 50,
+      "usd_at_receipt": 50,
       "price_note": "stablecoin-1-to-1"
     }
   ]


### PR DESCRIPTION
## Summary

- Append the explicitly approved 50 USDC Base donation from tokenbrice.eth; preserve every prior donation and all cost records.
- Receipt: https://basescan.org/tx/0xa4cc5b5d137afa130a92624e8a1073e03167c9445283b64a5580a870526ab033, confirmed at 2026-09-07 16:29:29 UTC. Native Circle USDC transfer to the Pharos Safe, verified sender/contract/receipt, no Safe self-activity, USD 50 at receipt under the existing stablecoin pricing policy.
- Fix the exact donation-ledger deployment classification: the claim Worker embeds this JSON, so donation-only changes must release both Worker and Pages. Costs remain Pages-only.

## Validation

- 75 focused funding/schema/eligibility/classifier tests passed; lint and diff checks passed.
- Schema assertion confirms one new row and unchanged history.
- Current non-held V9 publication gives USDC A+; the updated ledger yields USD 50 qualifying total for the donor. Eligibility is rechecked against current grades when claimed.
- Full generated-artifact convergence checked before publication.

## Acceptance

Verify both surfaces deploy for this commit, the funding page publishes the transfer, and the Worker contains the updated ledger. Maintainer signs the real claim on pharos.watch/api; no claim or token handling is performed by the release agent. Scope is the supplied transaction, not a whole-wallet reconciliation sweep.
