### PR TITLE
fix(live-reserves): look DOLA supply up by its registry id

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { mockD1 } from "@shared/test-utils/mock-d1";
 import {
   resolveBaseSymbol,
   bucketForAsset,
@@ -64,15 +65,30 @@ function dolaNetwork(options: {
   });
 }
 
-async function runDola(options: Parameters<typeof dolaNetwork>[0] = {}) {
+async function runDola(options: Parameters<typeof dolaNetwork>[0] = {}, db?: D1Database) {
   const network = dolaNetwork(options);
   const result = await fetchDolaInverseReserves(
     { id: "dola-inverse-finance" } as never,
     DOLA_LIVE_CONFIG,
     new AbortController().signal,
-    { chainRpcs: network.chainRpcs, nowSec: 1_776_330_494 },
+    { chainRpcs: network.chainRpcs, nowSec: 1_776_330_494, db },
   );
   return { result, network };
+}
+
+/** Stablecoins-cache D1 fixture keyed the way the registry publishes DOLA. */
+function dolaCacheDb(circulating: number) {
+  return mockD1([{
+    match: "SELECT value, updated_at FROM cache WHERE key = ?",
+    matchBinds: ["stablecoins"],
+    rows: [{
+      key: "stablecoins",
+      value: JSON.stringify({
+        peggedAssets: [{ id: "dola-inverse-finance", symbol: "DOLA", circulating: { peggedUSD: circulating } }],
+      }),
+      updated_at: 1_776_330_494 - 600,
+    }],
+  }]);
 }
 
 describe("resolveBaseSymbol", () => {
@@ -336,6 +352,16 @@ describe("fetchDolaInverseReserves PSM redemption telemetry", () => {
     expect(result.warnings ?? []).toEqual(
       expect.arrayContaining([expect.objectContaining({ code: "dola-psm-unreadable", effect: "info" })]),
     );
+    expectValidAdapterOutput("dola-inverse", result);
+  });
+
+
+  it("measures non-FiRM issuance from the fresh stablecoins cache instead of degrading", async () => {
+    const { result } = await runDola({}, dolaCacheDb(1_500_000));
+
+    expect(result.warnings ?? []).not.toContainEqual(expect.objectContaining({ code: "dola-supply-unavailable" }));
+    expect(result.metadata).toMatchObject({ supplyUsd: 1_500_000 });
+    expect(result.slices.find((slice) => slice.sourceKey === "dola-inverse:unattributed")?.pct).toBeCloseTo(33.3, 1);
     expectValidAdapterOutput("dola-inverse", result);
   });
 

--- a/worker/src/cron/reserve-adapters/dola-inverse.ts
+++ b/worker/src/cron/reserve-adapters/dola-inverse.ts
@@ -304,7 +304,7 @@ async function probeInversePsmSellFeeBps(signal: AbortSignal, ctx?: AdapterConte
 }
 
 export async function fetchDolaInverseReserves(
-  _coin: StablecoinMeta,
+  coin: StablecoinMeta,
   config: LiveReservesConfig,
   signal: AbortSignal,
   ctx?: AdapterContext,
@@ -318,7 +318,7 @@ export async function fetchDolaInverseReserves(
   const cached = ctx?.db ? await loadStablecoinsCache(ctx.db, { mode: "lenient", contract: "critical-fields" }) : null;
   const supplyCoin = cached && hasUsableStablecoinsPayload(cached)
     && cached.updatedAt != null && (ctx?.nowSec ?? Math.floor(Date.now() / 1000)) - cached.updatedAt <= 7200
-    ? cached.payload.peggedAssets.find((asset) => asset.id === "dola-inverse")
+    ? cached.payload.peggedAssets.find((asset) => asset.id === coin.id)
     : undefined;
   const circulatingUsd = supplyCoin ? getCirculatingRaw(supplyCoin) : 0;
   const supplyUsd = Number.isFinite(circulatingUsd) && circulatingUsd > 0 ? circulatingUsd : undefined;


### PR DESCRIPTION
Follow-up to #1064 from observing the first post-deploy `sync-redemption-backstops` run (08:17 UTC, still degraded at 6 missing-capacity rows).

`reserve_sync_state` for `dola-inverse-finance` shows `dola-supply-unavailable` on every run since 58fb6bbc5: the adapter searched the stablecoins cache for `peggedAssets[].id === "dola-inverse"`, but the registry publishes `dola-inverse-finance`. The degraded warning is not allowlisted for the redemption policy, so PSM capacity telemetry was withheld and DOLA became a permanent missing-capacity row. Use the coin id the adapter already receives.

Regression test seeds the cache fixture the way `djed-cardano.test.ts` does; it fails on `main` (warning emitted) and passes here. Focused checks: vitest dola-inverse (36), eslint on touched files, worker typecheck.

Acceptance: next `fourHourlyReserveSync` (12:11 UTC) should clear `dola-supply-unavailable` and drop DOLA from the missing-capacity set.