### PR TITLE
fix(shock-coverage): write the capture summary at measure time

### DIFF
--- a/docs/process/shock-coverage-refresh.md
+++ b/docs/process/shock-coverage-refresh.md
@@ -27,6 +27,8 @@ Worst-case gap between scheduled attempts is 48h, leaving a roughly 24h manual/r
 
 Each stage is a separate step, so a partial refresh (for example V1 succeeding and V2 failing) fails the job **before** any branch, commit, or PR is created. Nothing unverified reaches the registry.
 
+Each measure step writes the journal and its committed `<journal>.summary.json` projection together. The attestation and registry generators discover journals only through those summaries (raw bodies leave Git for R2 in the later upload step), so a summary written only at upload time would leave a fresh measurement invisible to the registry and fail the freshness assertion.
+
 ### Replay attestations are load-bearing
 
 `shared/lib/safety-score-v9/archetypes/cdp.ts` rejects any measurement where `exactReplayPassed` is false or `replayVerification` is null, with reason `stress-measurement-exact-replay-not-passed`. A journal committed without a matching attestation therefore scores exactly as if it were missing.

--- a/scripts/maintenance/measure-cdp-shock-coverage.ts
+++ b/scripts/maintenance/measure-cdp-shock-coverage.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { parseCliInteger, parseStrictCliArgs, runCliEntrypoint, writeCliHelpIfRequested } from "../lib/cli-args.mjs";
+import { buildMechanismCaptureSummary, summaryPathForCapture } from "../lib/mechanism-measurement/capture-summary";
 import { fetchBlockByNumber, pinBlock } from "../lib/mechanism-measurement/core";
 import { JournaledShockCaller, ReplayShockCaller } from "../lib/mechanism-measurement/shock-journal";
 import { measureConfiguredShockCoverageTarget } from "../lib/mechanism-measurement/shock-measure";
@@ -196,6 +197,18 @@ function assertExistingMeasurement(outPath: string, evidence: ShockCoverageEvide
   }
 }
 
+/**
+ * Only compact summaries are committed (raw bodies move to R2 later in the
+ * refresh), and the attestation and registry generators discover journals
+ * through those summaries. Project the summary here so a fresh measurement is
+ * visible to them before the upload step runs.
+ */
+function writeCaptureSummary(journalPath: string): void {
+  const root = process.cwd();
+  const summary = buildMechanismCaptureSummary(readFileSync(journalPath), journalPath, root);
+  writeFileSync(summaryPathForCapture(journalPath), `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+}
+
 async function replayEvidence(path: string): Promise<void> {
   const absolutePath = resolve(path);
   const recorded = ShockCoverageEvidenceV1Schema.parse(JSON.parse(readFileSync(absolutePath, "utf8")));
@@ -244,9 +257,11 @@ async function measureTarget(options: CliOptions, assetId: string): Promise<void
       } catch (error) {
         if (!(error && typeof error === "object" && "code" in error && error.code === "EEXIST")) throw error;
         assertExistingMeasurement(outPath, evidence);
+        writeCaptureSummary(outPath);
         console.log(`[shock-coverage] ${assetId}: identical measurement already recorded at ${outPath}`);
         return;
       }
+      writeCaptureSummary(outPath);
       console.log(
         `[shock-coverage] ${assetId}: block ${evidence.block.number} (${evidence.block.selection}) via ${rpcUrl}\n` +
           `  coverage50=${evidence.measuredFacts.stressLiquidationCoverageRatio} ` +


### PR DESCRIPTION
## Why

Every scheduled [Shock Coverage Refresh](https://github.com/TokenBrice/pharos-watch/actions/runs/34578384066) since 2026-09-05 fails at *Assert all targets produced a fresh scoring measurement* with the newest measurement still dated 2026-09-03, even though the three measure steps wrote fresh journals in the same run.

## Root cause

Since 494afa9dd moved raw capture bodies to R2, `generate-safety-score-v9-shock-coverage-attestations.ts` and `generate-safety-score-v9-shock-coverage-registry.ts` discover journals only through the committed `*.summary.json` projections. Those summaries were produced solely by `scripts/lib/mechanism-measurement/upload.ts`, which the workflow runs **after** attestation, registry regeneration and the freshness gate. Fresh journals were therefore invisible ("63 journals" before and after), and the gate failed on the stale 09-03 row.

## Fix

`measure-cdp-shock-coverage.ts` now projects the summary next to the journal (also on the idempotent identical-measurement path). The upload step later rewrites the identical summary and removes the raw body as before, so attestation still byte-replays the raw journal before anything reaches the registry. Process doc updated.

## Verification

Local rehearsal on `main`: measure lusd-liquity → summary emitted → attest ("64 attestations (1 replayed)") → registry ("64 journals") → freshness check `lusd-liquity: OK`. eslint/tsc/doc-sync clean. Rehearsal artifacts discarded.

## After merge

Dispatch the workflow manually (`gh workflow run "Shock Coverage Refresh" --ref main`) — the next scheduled attempt is 2026-09-13 03:41 UTC and LUSD/BOLD/BD are already past the 72h bound.