### PR TITLE
chore(v9): refresh CDP shock-coverage measurements

### DIFF
--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -591,19 +591,19 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
   ],
   "captures": [
     {
-      "sha256": "f36b48b5b97b58dd907def365d9c8afebc41dd1fe4b470cdc4ed7a942cbc4396",
-      "r2Key": "captures/bd-basedollar/2026-09-03-block-50816420-shock-coverage.json.gz"
+      "sha256": "9af131c08b78ce4e14c0092cb4875e314429826de768b25118e54155aa723282",
+      "r2Key": "captures/bd-basedollar/2026-09-11-block-51163570-shock-coverage.json.gz"
     },
     {
-      "sha256": "b97d2f1b1a8e5b69068fa7c76925f70aa27d40942b0b041146130460869df1ca",
-      "r2Key": "captures/bold-liquity/2026-09-03-block-25895460-shock-coverage.json.gz"
+      "sha256": "56a71b0c39cb1e36e300afa616c3a9a290541a561595d013166b86f94ae321e2",
+      "r2Key": "captures/bold-liquity/2026-09-11-block-25953096-shock-coverage.json.gz"
     },
     {
-      "sha256": "c7fce583e57e0bca69370d993af498d91b2a595d4a3c4a806746008530cd87dd",
-      "r2Key": "captures/lusd-liquity/2026-09-03-block-25895460-shock-coverage.json.gz"
+      "sha256": "52471c8bd25aedaef24169d729c2d0740d2c1e962e948ccf583038b59389cd2d",
+      "r2Key": "captures/lusd-liquity/2026-09-11-block-25953096-shock-coverage.json.gz"
     }
   ],
-  "digest": "467967c96823ec53d9ae63ebe0979aa64b8db18d46135f3438f011e9cc54e69a"
+  "digest": "538c8b54a8e3d7616ba82022a165b7a41c1c7788e545ab7c695a3d173744c507"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/safety-score-v9/mechanism-measurements/bd-basedollar/2026-09-11-block-51163570-shock-coverage.summary.json
+++ b/shared/data/safety-score-v9/mechanism-measurements/bd-basedollar/2026-09-11-block-51163570-shock-coverage.summary.json
@@ -1,0 +1,640 @@
+{
+  "mechanism": "bd-basedollar",
+  "date": "2026-09-11-block-51163570-shock-coverage",
+  "sha256": "9af131c08b78ce4e14c0092cb4875e314429826de768b25118e54155aa723282",
+  "bytes": 1364018,
+  "r2Key": "captures/bd-basedollar/2026-09-11-block-51163570-shock-coverage.json.gz",
+  "summary": {
+    "schemaVersion": 1,
+    "kind": "cdp-shock-coverage-measurement",
+    "assetId": "bd-basedollar",
+    "archetype": "cdp",
+    "family": "liquity-v2-shock-v1",
+    "applicability": {
+      "state": "measured",
+      "failureReason": null
+    },
+    "completeness": {
+      "complete": true,
+      "blockers": []
+    },
+    "block": {
+      "number": 51163570,
+      "hash": "0x0bd03909a827f629ea38ebff5b41556b85e17dd62b28b218156da870d7f04d58",
+      "timestampUnix": 1789116487,
+      "timestampIso": "2026-09-11T08:48:07.000Z"
+    },
+    "sourcePin": {
+      "repository": "https://github.com/basedollar/basedollar",
+      "commit": "fd325e5aeafa2e4881a4a2d32451dfc9dfa0d941",
+      "liquidationContractPath": "contracts/src/TroveManager.sol"
+    },
+    "shockPolicy": {
+      "scoreShockFractionPpm": 500000,
+      "sensitivityShockFractionsPpm": [
+        400000,
+        500000,
+        600000,
+        750000
+      ],
+      "debtReconciliationTolerancePpm": 1000
+    },
+    "measuredFacts": {
+      "applicability": "measured",
+      "failureReason": null,
+      "stressShockFraction": 0.5,
+      "stressLiquidatableDebt": "110615073860452573549154",
+      "stressPoolOffsetDebt": "18188756327277814894449",
+      "stressLiquidationCoverageRatio": 0.164432890495,
+      "branchContributions": [
+        {
+          "branchIndex": 0,
+          "stressLiquidatableDebt": "39224862305741717878052",
+          "stressPoolOffsetDebt": "5792989792711613697007",
+          "stressLiquidationCoverageRatio": 0.147686682685
+        },
+        {
+          "branchIndex": 1,
+          "stressLiquidatableDebt": "17213058496251337670812",
+          "stressPoolOffsetDebt": "6571239596804612996378",
+          "stressLiquidationCoverageRatio": 0.381758976665
+        },
+        {
+          "branchIndex": 2,
+          "stressLiquidatableDebt": "6506496182772182544253",
+          "stressPoolOffsetDebt": "1230003327400828811872",
+          "stressLiquidationCoverageRatio": 0.189042349806
+        },
+        {
+          "branchIndex": 3,
+          "stressLiquidatableDebt": "33139552899007858537169",
+          "stressPoolOffsetDebt": "2948478183406519986587",
+          "stressLiquidationCoverageRatio": 0.088971574009
+        },
+        {
+          "branchIndex": 4,
+          "stressLiquidatableDebt": "14531103976679476918868",
+          "stressPoolOffsetDebt": "1646045426954239402605",
+          "stressLiquidationCoverageRatio": 0.11327738275
+        }
+      ]
+    },
+    "codePins": [
+      {
+        "name": "bold-token",
+        "address": "0x252d36f435582ecb01686448d21e8c9ea0b2ca65",
+        "role": "token",
+        "codeHash": "0x81f94655a3c2dde6c1c6d945f99cf7d5e9221a335c323aa67c712c0c55cdc099"
+      },
+      {
+        "name": "collateral-registry",
+        "address": "0x7551ebfc8340b7f91874942be9c653733d4fb04f",
+        "role": "branch-enumerator",
+        "codeHash": "0x64a355fd127b3fd707b80f7421e49a2a0b5955af230c59995ae6f74e59026d21"
+      },
+      {
+        "name": "eth-usd-oracle-0",
+        "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-0",
+        "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+      },
+      {
+        "name": "collateral-token-0",
+        "address": "0x4200000000000000000000000000000000000006",
+        "role": "branch-collateral",
+        "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+      },
+      {
+        "name": "addresses-registry-0",
+        "address": "0xdad2735973d29e3a8ce26667774a624e0ea97556",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xb0a685fb22e858ffc522c63a887a76283c082b38de6a8c3d25b10225a2ad6aa4"
+      },
+      {
+        "name": "trove-manager-0",
+        "address": "0xa957d42c4c43eb97d5f71b8435eb638e5dd9f639",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x0317d6c5f7a2d866db157ccc6a2ca6a6d1f8a66a019818cc7b6c6a0759157fc2"
+      },
+      {
+        "name": "stability-pool-0",
+        "address": "0x7d837bf114785642d225d1101145ddb8af4ba438",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0xe76cbce56757dddfd371729edc9d51f0ab4658dc0f531b35bde61561c64959b7"
+      },
+      {
+        "name": "price-feed-0",
+        "address": "0x40b4199347af7738643ef4a12a771f7421b84e7f",
+        "role": "protocol-oracle",
+        "codeHash": "0xf4b0303494cc4a1e1e7cd834720e3d50c10c585fe0df43b079f140ebd52e44b4"
+      },
+      {
+        "name": "active-pool-0",
+        "address": "0x254a8267d4e12a8c0f283274632a18a33e49f7c0",
+        "role": "protocol-accounting",
+        "codeHash": "0x915d4ed8f0aa253d2ce17ee2aebad37503530d128838219a67b07f6b07e1ff83"
+      },
+      {
+        "name": "default-pool-0",
+        "address": "0xf5bba496a225211b102201bb54b57a29863ec876",
+        "role": "redistribution-accounting",
+        "codeHash": "0x4520dcae2d0b9e8af26f9884584b022a1b4635a551f852f694adb36335aa6029"
+      },
+      {
+        "name": "sorted-troves-0",
+        "address": "0x4f1d9102448fde06955a6cd20d085d6b468e92ad",
+        "role": "redemption-order",
+        "codeHash": "0xb53732a03b75addd1984b4e5136eb4f3f318604282d206c775eb1f7ca3f6fc85"
+      },
+      {
+        "name": "borrower-operations-0",
+        "address": "0x1867772fba1bcc13d94eb22f1d100ce524148a3f",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0xc07f190e14e624a02578e360d2519d3709f6b64dd7459483cdbcbb6e14ae8c0e"
+      },
+      {
+        "name": "trove-nft-0",
+        "address": "0xaed689cf95802fbbd9c8a787379d4dc66768c802",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0xed76abcdaf2ed86ff15af8d927e022eecb30bbab4247ab17233aa145767ad9e3"
+      },
+      {
+        "name": "gas-pool-0",
+        "address": "0x6cc943f5b476b8db11997899c517cee467258324",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+      },
+      {
+        "name": "coll-surplus-pool-0",
+        "address": "0xa304b224e332685bb741cf3d9877172e754983dd",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0x0887bdc56828740d6bed0c81c2b12af1643a57eb242f0a945532eb5fad6fc22a"
+      },
+      {
+        "name": "weth-0",
+        "address": "0x4200000000000000000000000000000000000006",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+      },
+      {
+        "name": "interest-router-0",
+        "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+      },
+      {
+        "name": "eth-usd-oracle-1",
+        "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-1",
+        "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+      },
+      {
+        "name": "secondary-oracle-1",
+        "address": "0x3df401c6ce98d6976acb7395460e32d99eb79d05",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "secondary-oracle-implementation-1",
+        "address": "0xbaf71b9a60c5fe2a6a448c0f2e3d66e42f5b5db8",
+        "role": "oracle-source-implementation",
+        "codeHash": "0xed5f39905daabd095648052e8f99bff1e2963c89d60057ec17d3e8ddfe44046e"
+      },
+      {
+        "name": "rate-provider-1",
+        "address": "0x00caeda3cb375a17a084b1bdce7136bb01bbd13d",
+        "role": "oracle-rate-provider",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "collateral-token-1",
+        "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+        "role": "branch-collateral",
+        "codeHash": "0x93d3f113d81097295a93cbfd054d390c99a34e1525054645567aa9c8c675812e"
+      },
+      {
+        "name": "addresses-registry-1",
+        "address": "0x3e35fcc70d2ed82adce6c1e8f111554a04b74f3f",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xe7751391facfccceb4e24d8ac8b1b54b3e55a8b41d5a0e188bd6189f75fe5f0d"
+      },
+      {
+        "name": "trove-manager-1",
+        "address": "0x79a6a3361eae4d4b80939206426f2320c11a4bfb",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x363d37d348f5676fa540db901a286b5f476c285236f0c6cfc01b1af196000a73"
+      },
+      {
+        "name": "stability-pool-1",
+        "address": "0xc65a05737d31e0f42c0806c739f3c88dd009c05f",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0x56137fbcd5f552b0009c90d65ec831d72a729920d53e2787b4b542ecbe0fdb2b"
+      },
+      {
+        "name": "price-feed-1",
+        "address": "0x176363a20ba1dc75b418d7954f5222499b276186",
+        "role": "protocol-oracle",
+        "codeHash": "0xb1350c03bf3cc33d87c97c7ec95f81c965f78d3dbd0cd18d61930135f927c2ae"
+      },
+      {
+        "name": "active-pool-1",
+        "address": "0x1021fefc406c9573ab3579fc55be13e3300ef6b1",
+        "role": "protocol-accounting",
+        "codeHash": "0x51a4c7f3db21ec076b5f4310995f497a5dc88470b352458ea848542abd54043b"
+      },
+      {
+        "name": "default-pool-1",
+        "address": "0x38062c11f7b89b234ca71f4fb39f8f8d32844a20",
+        "role": "redistribution-accounting",
+        "codeHash": "0xb5ec229111f3b048493417817dcfa9c5f6c05a4f1b3ccc9e5c0c565bc6f4c4e4"
+      },
+      {
+        "name": "sorted-troves-1",
+        "address": "0x4dad0339c1c33a247fc137f44bbc5dbe8df80ee1",
+        "role": "redemption-order",
+        "codeHash": "0x57f0382b5555d4f78b4146cf3b008128f22388b9851b4d7b6e01bd48fe0fe925"
+      },
+      {
+        "name": "borrower-operations-1",
+        "address": "0xc4b0a1011f2cb0438429724594d2ab3d4d8ef54a",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0x0c30d1e55e459f76a2605c41021e0029c33dc9bd2753b34b833ac511596bf03d"
+      },
+      {
+        "name": "trove-nft-1",
+        "address": "0xdb5747eaca2c4283ac56fe2b6ce84cb16c259990",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0x272bfd511409a2964853d93325f37f099da37f9f1ac600ce771cb29a0d00e53e"
+      },
+      {
+        "name": "gas-pool-1",
+        "address": "0x3f0dcac8a658056bb6be30979ecb26ea7702e72d",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+      },
+      {
+        "name": "coll-surplus-pool-1",
+        "address": "0xdc87cef2be8e9f7f1ad90260e5584e56835d43b3",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0x3954c2310bdace11c8c08c7940398542cb3feb46f9c1493f4ea252f57ebbd61a"
+      },
+      {
+        "name": "weth-1",
+        "address": "0x4200000000000000000000000000000000000006",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+      },
+      {
+        "name": "interest-router-1",
+        "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+      },
+      {
+        "name": "eth-usd-oracle-2",
+        "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-2",
+        "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+      },
+      {
+        "name": "secondary-oracle-2",
+        "address": "0xd75f2752ded6995106b163da472b96186ccf0441",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "secondary-oracle-implementation-2",
+        "address": "0x73f526b1611f9cebbacd3110b4df3a0342864ae7",
+        "role": "oracle-source-implementation",
+        "codeHash": "0xbc81013886a473137cefdd6e42e317bbed2b366f04049a9a74adc309b794cf4b"
+      },
+      {
+        "name": "rate-provider-2",
+        "address": "0x658843bb859b7b85ceab5cf77167e3f0a78dfe7f",
+        "role": "oracle-rate-provider",
+        "codeHash": "0xabb1c2ff9abff53a5bc2baf34be59a0a5b53a365e7de06db57f44555ab159f88"
+      },
+      {
+        "name": "collateral-token-2",
+        "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
+        "role": "branch-collateral",
+        "codeHash": "0x48b48023ed69f2c27cb6bca379617d5f0915fa9f4255da9fb4eaf13c19ef2090"
+      },
+      {
+        "name": "addresses-registry-2",
+        "address": "0xd4763ae6021927784a7a787c1a98b287f919d165",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xe7751391facfccceb4e24d8ac8b1b54b3e55a8b41d5a0e188bd6189f75fe5f0d"
+      },
+      {
+        "name": "trove-manager-2",
+        "address": "0xd31987fcba98f471b6e4220c52f7741b11b2fc5e",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x363d37d348f5676fa540db901a286b5f476c285236f0c6cfc01b1af196000a73"
+      },
+      {
+        "name": "stability-pool-2",
+        "address": "0x4eb3b6970fd358d34195b5d40e4eb64e0e3c0b6a",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0xf9f19cfa8c94b3d8053e4bf64af77dd8276bf43325e9e1d58d07db37c1b010cb"
+      },
+      {
+        "name": "price-feed-2",
+        "address": "0x6627b94533be5bba42d1aaaf982330e9746b6133",
+        "role": "protocol-oracle",
+        "codeHash": "0xdd33df2ea1ff23cb903d9d572410503d8ed3340832575d459d29e6f502d39532"
+      },
+      {
+        "name": "active-pool-2",
+        "address": "0x1b9a62798e8bae0cea4eb21b4b3775359beb819f",
+        "role": "protocol-accounting",
+        "codeHash": "0xe8c7a0694cffcb6afffa0f8bd5e9a150f791d4bffbf73102944559339e7b5148"
+      },
+      {
+        "name": "default-pool-2",
+        "address": "0x3d4eb96fb79ea0d79953423914b2a1472dbdc3cd",
+        "role": "redistribution-accounting",
+        "codeHash": "0xbfa1d1065e5f6f2bbc1412d9e37b84032d5856b3bdf869065c2d34f9eb9f4cdd"
+      },
+      {
+        "name": "sorted-troves-2",
+        "address": "0x637344c0634626bb5d3c8fd5cc0fb332558778f8",
+        "role": "redemption-order",
+        "codeHash": "0xc51ccb0b1e60e81ff5f74a79b1b903c90ab2ba818c061cd8d976b897c8eca52e"
+      },
+      {
+        "name": "borrower-operations-2",
+        "address": "0x69e933767974fcd7cabeea976226783f4b952521",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0x548c2f538db4de263c1c8f984e007ae9c4fc5468534b6eb25e10948bdea8d8b9"
+      },
+      {
+        "name": "trove-nft-2",
+        "address": "0xec22e1dd649a98d2718cc2d9afb69dbf25ed3fa6",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0x33286fad1071deb8519f6842b8bf918f384fedde709d3a3cb53fb122ac41cb1e"
+      },
+      {
+        "name": "gas-pool-2",
+        "address": "0xedf7bc788f83e17d9b62da279db02b1bcc582262",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+      },
+      {
+        "name": "coll-surplus-pool-2",
+        "address": "0x08699bd503d890ce7fd7bf216d7a6e9da1a179e4",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0x594d859bf002207c35190bedcd2b567167ba1605546286ff6a908754b35bf24a"
+      },
+      {
+        "name": "weth-2",
+        "address": "0x4200000000000000000000000000000000000006",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+      },
+      {
+        "name": "interest-router-2",
+        "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+      },
+      {
+        "name": "eth-usd-oracle-3",
+        "address": "0x021d31211f81bc37ed7c9d535380cfaddd62c111",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-3",
+        "address": "0x4b9188dcb11c73b62e49e10791ebc276a2a66fc5",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x4cdb78872a01897ae8c3de14dde2de62eb78ef4cb1a584c52a433b69f2825c86"
+      },
+      {
+        "name": "secondary-oracle-3",
+        "address": "0xb15fb0fe60b20689390f8306dedebc608ae1ff3d",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "secondary-oracle-implementation-3",
+        "address": "0xc1b881e528cf9b3ea4838a327fa0104f49da1489",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x8865f2d5b5d2e904d8e17bdf71fd105f7ed198900ec6fb6bb10971a6217da0eb"
+      },
+      {
+        "name": "collateral-token-3",
+        "address": "0x92a7aee8afaa71ba0a9cc04a3dbe1f34237c33e0",
+        "role": "branch-collateral",
+        "codeHash": "0xf11ac24a06c48272aea7f0b069a80a581425a40fb2dda5fbd2e1b553d90de3d5"
+      },
+      {
+        "name": "addresses-registry-3",
+        "address": "0x1fdea10dc1f6ff27ed9881bdf464fe070dda6f76",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xb0a685fb22e858ffc522c63a887a76283c082b38de6a8c3d25b10225a2ad6aa4"
+      },
+      {
+        "name": "trove-manager-3",
+        "address": "0x835b04eefbb0e32d8f75cfe96acb527a42f1a0d9",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x0317d6c5f7a2d866db157ccc6a2ca6a6d1f8a66a019818cc7b6c6a0759157fc2"
+      },
+      {
+        "name": "stability-pool-3",
+        "address": "0x6bd55dd953507641c84a03956760f83d29d65726",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0x164195d0c2d06c9e4a47e508caf059cb3f748684bd12e198a2ad17d0f265a274"
+      },
+      {
+        "name": "price-feed-3",
+        "address": "0x9e191d9f3f3c138c81753acf6f4ec32e84daa89e",
+        "role": "protocol-oracle",
+        "codeHash": "0xd2cad96079007d34a22091269db9a09d7786967256f99d1e789611d8d6ef7baf"
+      },
+      {
+        "name": "active-pool-3",
+        "address": "0xcaa72df531554087318eaf24646958500668b230",
+        "role": "protocol-accounting",
+        "codeHash": "0x3a30f669459e6b3b3015dd564fbc4d25c77e9a05a4b766e6f6ebb6d108d51618"
+      },
+      {
+        "name": "default-pool-3",
+        "address": "0x2019453c36c7272bdea78a0901d448595d8127d2",
+        "role": "redistribution-accounting",
+        "codeHash": "0xd2cf6778816edd886cf1921ab0fb0534d8e38ef6871dedaffb33b874e4642535"
+      },
+      {
+        "name": "sorted-troves-3",
+        "address": "0xe55530a4205ec2eda84adf9f5efb2f456d5cb721",
+        "role": "redemption-order",
+        "codeHash": "0x91d916776dd94ec9e2007976f4835ee095dcad31af13a7a5f61993f579fd239f"
+      },
+      {
+        "name": "borrower-operations-3",
+        "address": "0xb9a3c82486d0b6d72dec55fcc9192af09aaa393b",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0x5303ecac158abdeb8f356539c92610aaf307b23e43dfed88fa36916562fcf95a"
+      },
+      {
+        "name": "trove-nft-3",
+        "address": "0x9bac1f53bb7d309df424f16ee8a0bbb5803b9776",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0x33d9d1b13e4b881f77259103cf5859f2dc2e47570f2180b2678f0ca36747e07a"
+      },
+      {
+        "name": "gas-pool-3",
+        "address": "0x503fef97e449d0db569155d8a1408717ee05d363",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+      },
+      {
+        "name": "coll-surplus-pool-3",
+        "address": "0xeddcfb454f8756e992601666df5adb3389ef15e4",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0xc7fd318822aa6da3a716c13c6875aa1f7019d70988ea4d7606a69faac4727777"
+      },
+      {
+        "name": "weth-3",
+        "address": "0x4200000000000000000000000000000000000006",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+      },
+      {
+        "name": "interest-router-3",
+        "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+      },
+      {
+        "name": "eth-usd-oracle-4",
+        "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-4",
+        "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+      },
+      {
+        "name": "secondary-oracle-4",
+        "address": "0xbe3efb4209ee6962c309e3ce8650d54b326d9cd3",
+        "role": "oracle-source",
+        "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+      },
+      {
+        "name": "secondary-oracle-implementation-4",
+        "address": "0x9823fffe5ff8aaaa142dd6a398e501d49aaae9d9",
+        "role": "oracle-source-implementation",
+        "codeHash": "0xf22a5ad1ad14e9b6ed9b0e371c9ca75d1e1efe35568933f5af097343f414720c"
+      },
+      {
+        "name": "collateral-token-4",
+        "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
+        "role": "branch-collateral",
+        "codeHash": "0x8cd2f08c7ee9e6ab6e0180e8d6cb0613bbd54d2c4ae2ecdcaddfcdd9a226215b"
+      },
+      {
+        "name": "addresses-registry-4",
+        "address": "0x98f5ddda4c0250966a446d39167d0bfb8e4ca1b6",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xe7751391facfccceb4e24d8ac8b1b54b3e55a8b41d5a0e188bd6189f75fe5f0d"
+      },
+      {
+        "name": "trove-manager-4",
+        "address": "0x482de97e667330afba99f8ced527118aec66f15d",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x363d37d348f5676fa540db901a286b5f476c285236f0c6cfc01b1af196000a73"
+      },
+      {
+        "name": "stability-pool-4",
+        "address": "0x25afbb09d9804482ed8e24295be4a12704fe93ea",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0xc6e9460fdf3aa46f3b594465d0b4fbe4a27c2b2b8957283b8df71e65e87e8109"
+      },
+      {
+        "name": "price-feed-4",
+        "address": "0x23bb111e94ec68009da6b8fc50c19628a972b9e0",
+        "role": "protocol-oracle",
+        "codeHash": "0x126bcdb4430bcf77e3e9ad5e111dd20c2ab2cc1c0eef9efd9c4ccab2286cf8a9"
+      },
+      {
+        "name": "active-pool-4",
+        "address": "0xddac84ab417677f553cced8ababf497226112218",
+        "role": "protocol-accounting",
+        "codeHash": "0x41453918ea711d056566592c6092375f1c3ee91536d0d4687d72ca5e8f617b9c"
+      },
+      {
+        "name": "default-pool-4",
+        "address": "0xc8eb254aabd8a64193fea55aac36087393baf81b",
+        "role": "redistribution-accounting",
+        "codeHash": "0xd71e1c2268e5170c31c66318964fa05d974bea103a031ef8fc3db1150cc24f9d"
+      },
+      {
+        "name": "sorted-troves-4",
+        "address": "0x2792304889f35b60ccd79c3e173837bc6ec3ab44",
+        "role": "redemption-order",
+        "codeHash": "0x8b2837d637438aec533b93940bcdae5d85e669fc799a5aa88299008687d42cfa"
+      },
+      {
+        "name": "borrower-operations-4",
+        "address": "0xfa6e7e44e538b2cf7d73720b2b1942ab28abd1d5",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0xf0c72011594a373da689433929a25a981c8b22914e27bdadb69a772b94b7a7d7"
+      },
+      {
+        "name": "trove-nft-4",
+        "address": "0x2c3a69fe04c976a05e72033ac2433bcfaa15b68a",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0x85f16e52509dae287547f6d05b49bfa70a101662a29a6e5b60a527d930b78af3"
+      },
+      {
+        "name": "gas-pool-4",
+        "address": "0x4ad0d908d81c8b3f2d25ee29a1b01b31bee781bd",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+      },
+      {
+        "name": "coll-surplus-pool-4",
+        "address": "0x2d63ae9808cfabdab5cf6aa0202683726e46310f",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0xfef268801402fd5451967fb688fe0403cba596e0e843dc1b242f53bc8503cab3"
+      },
+      {
+        "name": "weth-4",
+        "address": "0x4200000000000000000000000000000000000006",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+      },
+      {
+        "name": "interest-router-4",
+        "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+      }
+    ],
+    "callsConsumed": 248,
+    "codePinsConsumed": 92,
+    "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bd-basedollar/2026-09-11-block-51163570-shock-coverage.json"
+  }
+}

--- a/shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-09-11-block-25953096-shock-coverage.summary.json
+++ b/shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-09-11-block-25953096-shock-coverage.summary.json
@@ -1,0 +1,412 @@
+{
+  "mechanism": "bold-liquity",
+  "date": "2026-09-11-block-25953096-shock-coverage",
+  "sha256": "56a71b0c39cb1e36e300afa616c3a9a290541a561595d013166b86f94ae321e2",
+  "bytes": 2665232,
+  "r2Key": "captures/bold-liquity/2026-09-11-block-25953096-shock-coverage.json.gz",
+  "summary": {
+    "schemaVersion": 1,
+    "kind": "cdp-shock-coverage-measurement",
+    "assetId": "bold-liquity",
+    "archetype": "cdp",
+    "family": "liquity-v2-shock-v1",
+    "applicability": {
+      "state": "measured",
+      "failureReason": null
+    },
+    "completeness": {
+      "complete": true,
+      "blockers": []
+    },
+    "block": {
+      "number": 25953096,
+      "hash": "0x93b5af0e7b1a6678e934cf8d3d1226a4947b0efd37f548a546856badddf0615a",
+      "timestampUnix": 1789116887,
+      "timestampIso": "2026-09-11T08:54:47.000Z"
+    },
+    "sourcePin": {
+      "repository": "https://github.com/liquity/bold",
+      "commit": "c8a5a4ee2e9dc024905856b6698a77d849c68c7e",
+      "liquidationContractPath": "contracts/src/TroveManager.sol"
+    },
+    "shockPolicy": {
+      "scoreShockFractionPpm": 500000,
+      "sensitivityShockFractionsPpm": [
+        400000,
+        500000,
+        600000,
+        750000
+      ],
+      "debtReconciliationTolerancePpm": 1000
+    },
+    "measuredFacts": {
+      "applicability": "measured",
+      "failureReason": null,
+      "stressShockFraction": 0.5,
+      "stressLiquidatableDebt": "15233565395984128595024940",
+      "stressPoolOffsetDebt": "11730761050827606483830615",
+      "stressLiquidationCoverageRatio": 0.770060110413,
+      "branchContributions": [
+        {
+          "branchIndex": 0,
+          "stressLiquidatableDebt": "4720906705876599400791559",
+          "stressPoolOffsetDebt": "4720906705876599400791559",
+          "stressLiquidationCoverageRatio": 1
+        },
+        {
+          "branchIndex": 1,
+          "stressLiquidatableDebt": "10499032276166729010267933",
+          "stressPoolOffsetDebt": "6996227931010206899073608",
+          "stressLiquidationCoverageRatio": 0.666368837334
+        },
+        {
+          "branchIndex": 2,
+          "stressLiquidatableDebt": "13626413940800183965448",
+          "stressPoolOffsetDebt": "13626413940800183965448",
+          "stressLiquidationCoverageRatio": 1
+        }
+      ]
+    },
+    "codePins": [
+      {
+        "name": "bold-token",
+        "address": "0x6440f144b7e50d6a8439336510312d2f54beb01d",
+        "role": "token",
+        "codeHash": "0xfee79b645b7275fbcb4e4891bb08f7c881e01378af3ecd74fb4dc19c47750d21"
+      },
+      {
+        "name": "collateral-registry",
+        "address": "0xf949982b91c8c61e952b3ba942cbbfaef5386684",
+        "role": "branch-enumerator",
+        "codeHash": "0x5478757832338027668465ab4e77c00e8dec71934941e18e49b52e6b572ed3f5"
+      },
+      {
+        "name": "eth-usd-oracle-0",
+        "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+        "role": "oracle-source",
+        "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-0",
+        "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+      },
+      {
+        "name": "collateral-token-0",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "role": "branch-collateral",
+        "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+      },
+      {
+        "name": "addresses-registry-0",
+        "address": "0x20f7c9ad66983f6523a0881d0f82406541417526",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0x5b2ea1e488451dfc36467287b48ca79a5297291567f483dcf95365ee28daaa5a"
+      },
+      {
+        "name": "trove-manager-0",
+        "address": "0x7bcb64b2c9206a5b699ed43363f6f98d4776cf5a",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x72d836bd8f8f2ea21eb31074bea3b8410f360e59fc9e00edafd2f0054b71a9fa"
+      },
+      {
+        "name": "stability-pool-0",
+        "address": "0x5721cbbd64fc7ae3ef44a0a3f9a790a9264cf9bf",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0x777b794d22f95d7db3d801c825afc8b57af074a9ab7c7af5876625e120ddaa39"
+      },
+      {
+        "name": "price-feed-0",
+        "address": "0xcc5f8102eb670c89a4a3c567c13851260303c24f",
+        "role": "protocol-oracle",
+        "codeHash": "0x584703b70ea8df7b1d0971cb69aa6751747735ffa110f50d6645cf113387fb8c"
+      },
+      {
+        "name": "active-pool-0",
+        "address": "0xeb5a8c825582965f1d84606e078620a84ab16afe",
+        "role": "protocol-accounting",
+        "codeHash": "0xdc859816c5ad16349bc6f0a17016db431648ab0c7f5fe8b6e7ece0a22bbe6dea"
+      },
+      {
+        "name": "default-pool-0",
+        "address": "0xd4558240d50c2e219a21c9d25afd513bb6e5b1a0",
+        "role": "redistribution-accounting",
+        "codeHash": "0x6b36badf295a64cdb794399abeaea82fabfd6f606375ce85a2cdb7649aa9de1f"
+      },
+      {
+        "name": "sorted-troves-0",
+        "address": "0xa25269e41bd072513849f2e64ad221e84f3063f4",
+        "role": "redemption-order",
+        "codeHash": "0x256861145481361c633e16675b57baea8c08cae4102afc26aa089db17584d26c"
+      },
+      {
+        "name": "borrower-operations-0",
+        "address": "0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0x447906ae6913c14793e4052ccd67808cbd38c373197b78aa752120e2f0bb2747"
+      },
+      {
+        "name": "trove-nft-0",
+        "address": "0x1a0fc0b843afd9140267d25d4e575cb37a838013",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0x927ae932def60a6f57961d072c1b601ac45f590fa950fa36ecfd9ff32103b22a"
+      },
+      {
+        "name": "gas-pool-0",
+        "address": "0x7b9ab3de4036cae51f1fa4ec0a2c2fd606bcf921",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0xac12f17a3db66a2b8414d5d856e37c619ef1c72cf59a0a0b08a7423d38ff8aee"
+      },
+      {
+        "name": "coll-surplus-pool-0",
+        "address": "0xedbe2509e502c0320d2e7f8b6746a49b4b50e2bf",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0xf1320038577d6fee7563370dfc62fa8f0e9e46c377dafa9091d6b97da0d70968"
+      },
+      {
+        "name": "weth-0",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+      },
+      {
+        "name": "interest-router-0",
+        "address": "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0x2a91933e7f237a53ed6f699474a7618e16623dbcebb26702e494a9ce6382d5ce"
+      },
+      {
+        "name": "eth-usd-oracle-1",
+        "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+        "role": "oracle-source",
+        "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-1",
+        "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+      },
+      {
+        "name": "secondary-oracle-1",
+        "address": "0xcfe54b5cd566ab89272946f602d76ea879cab4a8",
+        "role": "oracle-source",
+        "codeHash": "0xbd6f524cdc4268b6bd1bb6f77a8821faeea9c52ee9e0afa0b6d948ce82c966c2"
+      },
+      {
+        "name": "secondary-oracle-implementation-1",
+        "address": "0x26f196806f43e88fd27798c9e3fb8fdf4618240f",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+      },
+      {
+        "name": "rate-provider-1",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "role": "oracle-rate-provider",
+        "codeHash": "0x630181884786c962140041cffa3acffbf39d8c93bde1a62b7b55046e57400557"
+      },
+      {
+        "name": "collateral-token-1",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "role": "branch-collateral",
+        "codeHash": "0x630181884786c962140041cffa3acffbf39d8c93bde1a62b7b55046e57400557"
+      },
+      {
+        "name": "addresses-registry-1",
+        "address": "0x8d733f7ea7c23cbea7c613b6ebd845d46d3aac54",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xe9346fd91922f3d4d64279fde0a5d76c8337760e45149b5922417d5658b8d63f"
+      },
+      {
+        "name": "trove-manager-1",
+        "address": "0xa2895d6a3bf110561dfe4b71ca539d84e1928b22",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x64a22fbff8d3493d5f2e88c02a6f27c8a1c3b934dba2ae62df11b553b539e741"
+      },
+      {
+        "name": "stability-pool-1",
+        "address": "0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0xa7fc5531b7aa2f97ccff086ba951172a4deb6547c7427ff352ada086137dcbbf"
+      },
+      {
+        "name": "price-feed-1",
+        "address": "0xe7aa2ba9e086a379d3beb224098bc634a46e314e",
+        "role": "protocol-oracle",
+        "codeHash": "0x20f254eb11744222398d4bdc32a401f58bbf122ad375a4dbcc9c8d2634c7ac5d"
+      },
+      {
+        "name": "active-pool-1",
+        "address": "0x531a8f99c70d6a56a7cee02d6b4281650d7919a0",
+        "role": "protocol-accounting",
+        "codeHash": "0xeebae2c4062853955e4d00fab1b0900755c1b64df3e159b9e1ceeb26be70adde"
+      },
+      {
+        "name": "default-pool-1",
+        "address": "0xd796e1648526400386cc4d12fa05e5f11e6a22a1",
+        "role": "redistribution-accounting",
+        "codeHash": "0x11761d1e8a516ec55da92ed8b033097c30fe1f5ead4d176e52cc3d3fc5b6ef6f"
+      },
+      {
+        "name": "sorted-troves-1",
+        "address": "0x84eb85a8c25049255614f0536bea8f31682e86f1",
+        "role": "redemption-order",
+        "codeHash": "0x462dae7a1efc69ab98f9e91c92f5a925e0aebcc5256f7b78f59cc7c6f39e27ab"
+      },
+      {
+        "name": "borrower-operations-1",
+        "address": "0xa741a32f9dcfe6adba088fd0f97e90742d7d5da3",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0xae3cc62ddc87b1f972460bc05e6da66dcde3c222757c30b2a4c5f6122b53d251"
+      },
+      {
+        "name": "trove-nft-1",
+        "address": "0x857aecebf75f1012dc18e15020c97096aea31b04",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0x09ffd8bd34367164f932de6f86557c8ef7f34223fba6e2f352f1c100ee6ef439"
+      },
+      {
+        "name": "gas-pool-1",
+        "address": "0x8c44fba379d8a8608c0e29b2729deb75a981db1f",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0xac12f17a3db66a2b8414d5d856e37c619ef1c72cf59a0a0b08a7423d38ff8aee"
+      },
+      {
+        "name": "coll-surplus-pool-1",
+        "address": "0x36e6cbdf68f64cf00fc3a6c634a25be32dd0a235",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0xc3f9f82660d6b1e4fccbc618d25fb9d66f07eb743afb98bd7c4534ec8ad86e17"
+      },
+      {
+        "name": "weth-1",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+      },
+      {
+        "name": "interest-router-1",
+        "address": "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0x2a91933e7f237a53ed6f699474a7618e16623dbcebb26702e494a9ce6382d5ce"
+      },
+      {
+        "name": "eth-usd-oracle-2",
+        "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+        "role": "oracle-source",
+        "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+      },
+      {
+        "name": "eth-usd-oracle-implementation-2",
+        "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+      },
+      {
+        "name": "secondary-oracle-2",
+        "address": "0x536218f9e9eb48863970252233c8f271f554c2d0",
+        "role": "oracle-source",
+        "codeHash": "0xbd6f524cdc4268b6bd1bb6f77a8821faeea9c52ee9e0afa0b6d948ce82c966c2"
+      },
+      {
+        "name": "secondary-oracle-implementation-2",
+        "address": "0xc77904cd2ca0806cc3db0819e9630ff3e2f6093d",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x13f277b777164702d0b469a459d0cc7989958c7447e0c46e47c0575bbd3b5d2f"
+      },
+      {
+        "name": "rate-provider-2",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "role": "oracle-rate-provider",
+        "codeHash": "0xe34255314ec42825a6444800e6894665b8c74e84e9dd2f20866f7057812b3adf"
+      },
+      {
+        "name": "collateral-token-2",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "role": "branch-collateral",
+        "codeHash": "0xe34255314ec42825a6444800e6894665b8c74e84e9dd2f20866f7057812b3adf"
+      },
+      {
+        "name": "addresses-registry-2",
+        "address": "0x6106046f031a22713697e04c08b330ddaf3e8789",
+        "role": "parameter-and-graph-registry",
+        "codeHash": "0xe9346fd91922f3d4d64279fde0a5d76c8337760e45149b5922417d5658b8d63f"
+      },
+      {
+        "name": "trove-manager-2",
+        "address": "0xb2b2abeb5c357a234363ff5d180912d319e3e19e",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x64a22fbff8d3493d5f2e88c02a6f27c8a1c3b934dba2ae62df11b553b539e741"
+      },
+      {
+        "name": "stability-pool-2",
+        "address": "0xd442e41019b7f5c4dd78f50dc03726c446148695",
+        "role": "branch-local-committed-pool",
+        "codeHash": "0x524c5be28739d527168541b5444ea2fed9352a6c9ae2dbae0259833ea9444ced"
+      },
+      {
+        "name": "price-feed-2",
+        "address": "0x34f1e9c7dcc279ec70d3c4488eb2d80fba8b7b2b",
+        "role": "protocol-oracle",
+        "codeHash": "0x3da3a6ece7f18d93d85ed072e2272a4e88d999df891d3517cb8e7f32cd86b3b5"
+      },
+      {
+        "name": "active-pool-2",
+        "address": "0x9074d72cc82dad1e13e454755aa8f144c479532f",
+        "role": "protocol-accounting",
+        "codeHash": "0x733dc9cdcff48fd6b8d80760fbf2ad382203b96d28a889aa4129732a89f62bc5"
+      },
+      {
+        "name": "default-pool-2",
+        "address": "0x5cc5cefd034fdc4728d487a72ca58a410cddcd6b",
+        "role": "redistribution-accounting",
+        "codeHash": "0x6ef5b7c5a128829199bf602906f13a3b7b977d45aa603a382f461f61e89292e5"
+      },
+      {
+        "name": "sorted-troves-2",
+        "address": "0x14d8d8011df2b396ed2bbc4959bb73250324f386",
+        "role": "redemption-order",
+        "codeHash": "0x116ffff3a415ac0b3ababd6dde84006cd13c45c9317ada0de010d2bdd553c592"
+      },
+      {
+        "name": "borrower-operations-2",
+        "address": "0xe8119fc02953b27a1b48d2573855738485a17329",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0x3a695e4cfa4b57076fab2f93f4eeb75b7d902f9953c542718c53a1e2b79eab57"
+      },
+      {
+        "name": "trove-nft-2",
+        "address": "0x7ae430e25b67f19b431e1d1dc048a5bcf24c0873",
+        "role": "liquidation-owner-lookup",
+        "codeHash": "0xe5eb8e2d17276215074323cb5f9449f161ab622261548a1cfcc850de683b026c"
+      },
+      {
+        "name": "gas-pool-2",
+        "address": "0x45c81dce308389e1bee63ae30a04fb1e148dad41",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0xac12f17a3db66a2b8414d5d856e37c619ef1c72cf59a0a0b08a7423d38ff8aee"
+      },
+      {
+        "name": "coll-surplus-pool-2",
+        "address": "0xba4a2bd8b76df84cac98eba3f4b967d8423192bf",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0xec13cbc666728b0a1842ed11bf17e33c5aff1c636e6ace30ff10226edf832063"
+      },
+      {
+        "name": "weth-2",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "role": "liquidation-gas-compensation-token",
+        "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+      },
+      {
+        "name": "interest-router-2",
+        "address": "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1",
+        "role": "liquidation-interest-minting",
+        "codeHash": "0x2a91933e7f237a53ed6f699474a7618e16623dbcebb26702e494a9ce6382d5ce"
+      }
+    ],
+    "callsConsumed": 761,
+    "codePinsConsumed": 56,
+    "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-09-11-block-25953096-shock-coverage.json"
+  }
+}

--- a/shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-09-11-block-25953096-shock-coverage.summary.json
+++ b/shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-09-11-block-25953096-shock-coverage.summary.json
@@ -1,0 +1,148 @@
+{
+  "mechanism": "lusd-liquity",
+  "date": "2026-09-11-block-25953096-shock-coverage",
+  "sha256": "52471c8bd25aedaef24169d729c2d0740d2c1e962e948ccf583038b59389cd2d",
+  "bytes": 624986,
+  "r2Key": "captures/lusd-liquity/2026-09-11-block-25953096-shock-coverage.json.gz",
+  "summary": {
+    "schemaVersion": 1,
+    "kind": "cdp-shock-coverage-measurement",
+    "assetId": "lusd-liquity",
+    "archetype": "cdp",
+    "family": "liquity-v1-shock-v1",
+    "applicability": {
+      "state": "measured",
+      "failureReason": null
+    },
+    "completeness": {
+      "complete": true,
+      "blockers": []
+    },
+    "block": {
+      "number": 25953096,
+      "hash": "0x93b5af0e7b1a6678e934cf8d3d1226a4947b0efd37f548a546856badddf0615a",
+      "timestampUnix": 1789116887,
+      "timestampIso": "2026-09-11T08:54:47.000Z"
+    },
+    "sourcePin": {
+      "repository": "https://github.com/liquity/dev",
+      "commit": "5174ecd0da4842157aba989499200d690b7e374f",
+      "liquidationContractPath": "packages/contracts/contracts/TroveManager.sol"
+    },
+    "shockPolicy": {
+      "scoreShockFractionPpm": 500000,
+      "sensitivityShockFractionsPpm": [
+        400000,
+        500000,
+        600000,
+        750000
+      ],
+      "debtReconciliationTolerancePpm": 1000
+    },
+    "measuredFacts": {
+      "applicability": "measured",
+      "failureReason": null,
+      "stressShockFraction": 0.5,
+      "stressLiquidatableDebt": "0",
+      "stressPoolOffsetDebt": "0",
+      "stressLiquidationCoverageRatio": 1,
+      "branchContributions": [
+        {
+          "branchIndex": 0,
+          "stressLiquidatableDebt": "0",
+          "stressPoolOffsetDebt": "0",
+          "stressLiquidationCoverageRatio": 1
+        }
+      ]
+    },
+    "codePins": [
+      {
+        "name": "lusd-token",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "role": "token",
+        "codeHash": "0xa607f4c8379ffb91323184b39d374287ea702b699648610ba87b29fd4f9b00a1"
+      },
+      {
+        "name": "trove-manager",
+        "address": "0xa39739ef8b0231dbfa0dcda07d7e29faabcf4bb2",
+        "role": "liquidation-state-machine",
+        "codeHash": "0x33404f55d90f42f5d4684d3eb52d4afc7ee41fd86f9a0ff9c0afcf0af0a410bb"
+      },
+      {
+        "name": "stability-pool",
+        "address": "0x66017d22b0f8556afdd19fc67041899eb65a21bb",
+        "role": "committed-pool",
+        "codeHash": "0x9c3b21a3a97ad953c529831bb02b0fcd0ff03fc43054bac66a528702025d5bfe"
+      },
+      {
+        "name": "price-feed",
+        "address": "0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
+        "role": "protocol-oracle",
+        "codeHash": "0x8c867f65098a2714f2a6f57ea929da0a60a84813e837e31280f2ee3fa6cd92cd"
+      },
+      {
+        "name": "sorted-troves",
+        "address": "0x8fdd3fbfeb32b28fb73555518f8b361bcea741a6",
+        "role": "liquidation-order",
+        "codeHash": "0xde3f1240d86a227b42772efa8df3a6c96f7f1c6fce25106551d859fadf63d9b7"
+      },
+      {
+        "name": "active-pool",
+        "address": "0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f",
+        "role": "protocol-accounting",
+        "codeHash": "0x05861911a299411e528997f0d9078a5114bc29529befe386e53f639caab45705"
+      },
+      {
+        "name": "default-pool",
+        "address": "0x896a3f03176f05cfbb4f006bfcd8723f2b0d741c",
+        "role": "redistribution-accounting",
+        "codeHash": "0x8c5f0a005c7b308aff2fd2de3ee2f1f2e35c3f03c10d797391536668c4eea5b4"
+      },
+      {
+        "name": "borrower-operations",
+        "address": "0x24179cd81c9e782a4096035f7ec97fb8b783e007",
+        "role": "liquidation-state-cleanup",
+        "codeHash": "0xcbe65d5fc2c48608b31fc5c0b97f3b0c4853cdf3b20f681995eba3e44e51be77"
+      },
+      {
+        "name": "gas-pool",
+        "address": "0x9555b042f969e561855e5f28cb1230819149a8d9",
+        "role": "liquidation-gas-compensation",
+        "codeHash": "0x78721f13761f7378853c4a5bcc87ddbd38d95d06941d0fc0c54d73b12e00b746"
+      },
+      {
+        "name": "coll-surplus-pool",
+        "address": "0x3d32e8b97ed5881324241cf03b2da5e2ebce5521",
+        "role": "liquidation-collateral-surplus",
+        "codeHash": "0x7d5494b64358562eff75a949c075ce83e207406e7eca114e4cd187079e0aa01e"
+      },
+      {
+        "name": "chainlink-price-aggregator",
+        "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+        "role": "oracle-source",
+        "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+      },
+      {
+        "name": "chainlink-price-aggregator-implementation",
+        "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+        "role": "oracle-source-implementation",
+        "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+      },
+      {
+        "name": "tellor-caller",
+        "address": "0xad430500ecda11e38c9bcb08a702274b94641112",
+        "role": "oracle-fallback",
+        "codeHash": "0x5002b4c59dee316a2410f60a901d2d5077878ac18daa0be7e5bfd138511e845f"
+      },
+      {
+        "name": "tellor-oracle",
+        "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+        "role": "oracle-fallback-source",
+        "codeHash": "0x18df49952ae206a293436515440bff85ba7a87d1ddf9ab0aab4e1fba63c11fbb"
+      }
+    ],
+    "callsConsumed": 244,
+    "codePinsConsumed": 14,
+    "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-09-11-block-25953096-shock-coverage.json"
+  }
+}

--- a/shared/data/safety-score-v9/shock-coverage-measurements-v1.json
+++ b/shared/data/safety-score-v9/shock-coverage-measurements-v1.json
@@ -5091,6 +5091,642 @@
       ]
     },
     {
+      "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bd-basedollar/2026-09-11-block-51163570-shock-coverage.json",
+      "journalSha256": "9af131c08b78ce4e14c0092cb4875e314429826de768b25118e54155aa723282",
+      "assetId": "bd-basedollar",
+      "archetype": "cdp",
+      "family": "liquity-v2-shock-v1",
+      "applicability": "measured",
+      "failureReason": null,
+      "complete": true,
+      "blockers": [],
+      "exactReplayPassed": true,
+      "replayVerification": {
+        "attestationPath": "shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json",
+        "attestedAt": "2026-09-11",
+        "toolPath": "scripts/maintenance/measure-cdp-shock-coverage.ts",
+        "toolVersion": "1",
+        "mode": "offline-byte-identical",
+        "callsConsumed": 248,
+        "codePinsConsumed": 92
+      },
+      "block": {
+        "number": 51163570,
+        "hash": "0x0bd03909a827f629ea38ebff5b41556b85e17dd62b28b218156da870d7f04d58",
+        "timestampUnix": 1789116487,
+        "timestampIso": "2026-09-11T08:48:07.000Z"
+      },
+      "sourcePin": {
+        "repository": "https://github.com/basedollar/basedollar",
+        "commit": "fd325e5aeafa2e4881a4a2d32451dfc9dfa0d941",
+        "liquidationContractPath": "contracts/src/TroveManager.sol"
+      },
+      "shockPolicy": {
+        "scoreShockFractionPpm": 500000,
+        "sensitivityShockFractionsPpm": [
+          400000,
+          500000,
+          600000,
+          750000
+        ],
+        "debtReconciliationTolerancePpm": 1000
+      },
+      "measuredFacts": {
+        "applicability": "measured",
+        "failureReason": null,
+        "stressShockFraction": 0.5,
+        "stressLiquidatableDebt": "110615073860452573549154",
+        "stressPoolOffsetDebt": "18188756327277814894449",
+        "stressLiquidationCoverageRatio": 0.164432890495,
+        "branchContributions": [
+          {
+            "branchIndex": 0,
+            "stressLiquidatableDebt": "39224862305741717878052",
+            "stressPoolOffsetDebt": "5792989792711613697007",
+            "stressLiquidationCoverageRatio": 0.147686682685
+          },
+          {
+            "branchIndex": 1,
+            "stressLiquidatableDebt": "17213058496251337670812",
+            "stressPoolOffsetDebt": "6571239596804612996378",
+            "stressLiquidationCoverageRatio": 0.381758976665
+          },
+          {
+            "branchIndex": 2,
+            "stressLiquidatableDebt": "6506496182772182544253",
+            "stressPoolOffsetDebt": "1230003327400828811872",
+            "stressLiquidationCoverageRatio": 0.189042349806
+          },
+          {
+            "branchIndex": 3,
+            "stressLiquidatableDebt": "33139552899007858537169",
+            "stressPoolOffsetDebt": "2948478183406519986587",
+            "stressLiquidationCoverageRatio": 0.088971574009
+          },
+          {
+            "branchIndex": 4,
+            "stressLiquidatableDebt": "14531103976679476918868",
+            "stressPoolOffsetDebt": "1646045426954239402605",
+            "stressLiquidationCoverageRatio": 0.11327738275
+          }
+        ]
+      },
+      "codePins": [
+        {
+          "name": "bold-token",
+          "address": "0x252d36f435582ecb01686448d21e8c9ea0b2ca65",
+          "role": "token",
+          "codeHash": "0x81f94655a3c2dde6c1c6d945f99cf7d5e9221a335c323aa67c712c0c55cdc099"
+        },
+        {
+          "name": "collateral-registry",
+          "address": "0x7551ebfc8340b7f91874942be9c653733d4fb04f",
+          "role": "branch-enumerator",
+          "codeHash": "0x64a355fd127b3fd707b80f7421e49a2a0b5955af230c59995ae6f74e59026d21"
+        },
+        {
+          "name": "eth-usd-oracle-0",
+          "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-0",
+          "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+        },
+        {
+          "name": "collateral-token-0",
+          "address": "0x4200000000000000000000000000000000000006",
+          "role": "branch-collateral",
+          "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+        },
+        {
+          "name": "addresses-registry-0",
+          "address": "0xdad2735973d29e3a8ce26667774a624e0ea97556",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xb0a685fb22e858ffc522c63a887a76283c082b38de6a8c3d25b10225a2ad6aa4"
+        },
+        {
+          "name": "trove-manager-0",
+          "address": "0xa957d42c4c43eb97d5f71b8435eb638e5dd9f639",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x0317d6c5f7a2d866db157ccc6a2ca6a6d1f8a66a019818cc7b6c6a0759157fc2"
+        },
+        {
+          "name": "stability-pool-0",
+          "address": "0x7d837bf114785642d225d1101145ddb8af4ba438",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0xe76cbce56757dddfd371729edc9d51f0ab4658dc0f531b35bde61561c64959b7"
+        },
+        {
+          "name": "price-feed-0",
+          "address": "0x40b4199347af7738643ef4a12a771f7421b84e7f",
+          "role": "protocol-oracle",
+          "codeHash": "0xf4b0303494cc4a1e1e7cd834720e3d50c10c585fe0df43b079f140ebd52e44b4"
+        },
+        {
+          "name": "active-pool-0",
+          "address": "0x254a8267d4e12a8c0f283274632a18a33e49f7c0",
+          "role": "protocol-accounting",
+          "codeHash": "0x915d4ed8f0aa253d2ce17ee2aebad37503530d128838219a67b07f6b07e1ff83"
+        },
+        {
+          "name": "default-pool-0",
+          "address": "0xf5bba496a225211b102201bb54b57a29863ec876",
+          "role": "redistribution-accounting",
+          "codeHash": "0x4520dcae2d0b9e8af26f9884584b022a1b4635a551f852f694adb36335aa6029"
+        },
+        {
+          "name": "sorted-troves-0",
+          "address": "0x4f1d9102448fde06955a6cd20d085d6b468e92ad",
+          "role": "redemption-order",
+          "codeHash": "0xb53732a03b75addd1984b4e5136eb4f3f318604282d206c775eb1f7ca3f6fc85"
+        },
+        {
+          "name": "borrower-operations-0",
+          "address": "0x1867772fba1bcc13d94eb22f1d100ce524148a3f",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0xc07f190e14e624a02578e360d2519d3709f6b64dd7459483cdbcbb6e14ae8c0e"
+        },
+        {
+          "name": "trove-nft-0",
+          "address": "0xaed689cf95802fbbd9c8a787379d4dc66768c802",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0xed76abcdaf2ed86ff15af8d927e022eecb30bbab4247ab17233aa145767ad9e3"
+        },
+        {
+          "name": "gas-pool-0",
+          "address": "0x6cc943f5b476b8db11997899c517cee467258324",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+        },
+        {
+          "name": "coll-surplus-pool-0",
+          "address": "0xa304b224e332685bb741cf3d9877172e754983dd",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0x0887bdc56828740d6bed0c81c2b12af1643a57eb242f0a945532eb5fad6fc22a"
+        },
+        {
+          "name": "weth-0",
+          "address": "0x4200000000000000000000000000000000000006",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+        },
+        {
+          "name": "interest-router-0",
+          "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+        },
+        {
+          "name": "eth-usd-oracle-1",
+          "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-1",
+          "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+        },
+        {
+          "name": "secondary-oracle-1",
+          "address": "0x3df401c6ce98d6976acb7395460e32d99eb79d05",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "secondary-oracle-implementation-1",
+          "address": "0xbaf71b9a60c5fe2a6a448c0f2e3d66e42f5b5db8",
+          "role": "oracle-source-implementation",
+          "codeHash": "0xed5f39905daabd095648052e8f99bff1e2963c89d60057ec17d3e8ddfe44046e"
+        },
+        {
+          "name": "rate-provider-1",
+          "address": "0x00caeda3cb375a17a084b1bdce7136bb01bbd13d",
+          "role": "oracle-rate-provider",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "collateral-token-1",
+          "address": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+          "role": "branch-collateral",
+          "codeHash": "0x93d3f113d81097295a93cbfd054d390c99a34e1525054645567aa9c8c675812e"
+        },
+        {
+          "name": "addresses-registry-1",
+          "address": "0x3e35fcc70d2ed82adce6c1e8f111554a04b74f3f",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xe7751391facfccceb4e24d8ac8b1b54b3e55a8b41d5a0e188bd6189f75fe5f0d"
+        },
+        {
+          "name": "trove-manager-1",
+          "address": "0x79a6a3361eae4d4b80939206426f2320c11a4bfb",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x363d37d348f5676fa540db901a286b5f476c285236f0c6cfc01b1af196000a73"
+        },
+        {
+          "name": "stability-pool-1",
+          "address": "0xc65a05737d31e0f42c0806c739f3c88dd009c05f",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0x56137fbcd5f552b0009c90d65ec831d72a729920d53e2787b4b542ecbe0fdb2b"
+        },
+        {
+          "name": "price-feed-1",
+          "address": "0x176363a20ba1dc75b418d7954f5222499b276186",
+          "role": "protocol-oracle",
+          "codeHash": "0xb1350c03bf3cc33d87c97c7ec95f81c965f78d3dbd0cd18d61930135f927c2ae"
+        },
+        {
+          "name": "active-pool-1",
+          "address": "0x1021fefc406c9573ab3579fc55be13e3300ef6b1",
+          "role": "protocol-accounting",
+          "codeHash": "0x51a4c7f3db21ec076b5f4310995f497a5dc88470b352458ea848542abd54043b"
+        },
+        {
+          "name": "default-pool-1",
+          "address": "0x38062c11f7b89b234ca71f4fb39f8f8d32844a20",
+          "role": "redistribution-accounting",
+          "codeHash": "0xb5ec229111f3b048493417817dcfa9c5f6c05a4f1b3ccc9e5c0c565bc6f4c4e4"
+        },
+        {
+          "name": "sorted-troves-1",
+          "address": "0x4dad0339c1c33a247fc137f44bbc5dbe8df80ee1",
+          "role": "redemption-order",
+          "codeHash": "0x57f0382b5555d4f78b4146cf3b008128f22388b9851b4d7b6e01bd48fe0fe925"
+        },
+        {
+          "name": "borrower-operations-1",
+          "address": "0xc4b0a1011f2cb0438429724594d2ab3d4d8ef54a",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0x0c30d1e55e459f76a2605c41021e0029c33dc9bd2753b34b833ac511596bf03d"
+        },
+        {
+          "name": "trove-nft-1",
+          "address": "0xdb5747eaca2c4283ac56fe2b6ce84cb16c259990",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0x272bfd511409a2964853d93325f37f099da37f9f1ac600ce771cb29a0d00e53e"
+        },
+        {
+          "name": "gas-pool-1",
+          "address": "0x3f0dcac8a658056bb6be30979ecb26ea7702e72d",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+        },
+        {
+          "name": "coll-surplus-pool-1",
+          "address": "0xdc87cef2be8e9f7f1ad90260e5584e56835d43b3",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0x3954c2310bdace11c8c08c7940398542cb3feb46f9c1493f4ea252f57ebbd61a"
+        },
+        {
+          "name": "weth-1",
+          "address": "0x4200000000000000000000000000000000000006",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+        },
+        {
+          "name": "interest-router-1",
+          "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+        },
+        {
+          "name": "eth-usd-oracle-2",
+          "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-2",
+          "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+        },
+        {
+          "name": "secondary-oracle-2",
+          "address": "0xd75f2752ded6995106b163da472b96186ccf0441",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "secondary-oracle-implementation-2",
+          "address": "0x73f526b1611f9cebbacd3110b4df3a0342864ae7",
+          "role": "oracle-source-implementation",
+          "codeHash": "0xbc81013886a473137cefdd6e42e317bbed2b366f04049a9a74adc309b794cf4b"
+        },
+        {
+          "name": "rate-provider-2",
+          "address": "0x658843bb859b7b85ceab5cf77167e3f0a78dfe7f",
+          "role": "oracle-rate-provider",
+          "codeHash": "0xabb1c2ff9abff53a5bc2baf34be59a0a5b53a365e7de06db57f44555ab159f88"
+        },
+        {
+          "name": "collateral-token-2",
+          "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
+          "role": "branch-collateral",
+          "codeHash": "0x48b48023ed69f2c27cb6bca379617d5f0915fa9f4255da9fb4eaf13c19ef2090"
+        },
+        {
+          "name": "addresses-registry-2",
+          "address": "0xd4763ae6021927784a7a787c1a98b287f919d165",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xe7751391facfccceb4e24d8ac8b1b54b3e55a8b41d5a0e188bd6189f75fe5f0d"
+        },
+        {
+          "name": "trove-manager-2",
+          "address": "0xd31987fcba98f471b6e4220c52f7741b11b2fc5e",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x363d37d348f5676fa540db901a286b5f476c285236f0c6cfc01b1af196000a73"
+        },
+        {
+          "name": "stability-pool-2",
+          "address": "0x4eb3b6970fd358d34195b5d40e4eb64e0e3c0b6a",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0xf9f19cfa8c94b3d8053e4bf64af77dd8276bf43325e9e1d58d07db37c1b010cb"
+        },
+        {
+          "name": "price-feed-2",
+          "address": "0x6627b94533be5bba42d1aaaf982330e9746b6133",
+          "role": "protocol-oracle",
+          "codeHash": "0xdd33df2ea1ff23cb903d9d572410503d8ed3340832575d459d29e6f502d39532"
+        },
+        {
+          "name": "active-pool-2",
+          "address": "0x1b9a62798e8bae0cea4eb21b4b3775359beb819f",
+          "role": "protocol-accounting",
+          "codeHash": "0xe8c7a0694cffcb6afffa0f8bd5e9a150f791d4bffbf73102944559339e7b5148"
+        },
+        {
+          "name": "default-pool-2",
+          "address": "0x3d4eb96fb79ea0d79953423914b2a1472dbdc3cd",
+          "role": "redistribution-accounting",
+          "codeHash": "0xbfa1d1065e5f6f2bbc1412d9e37b84032d5856b3bdf869065c2d34f9eb9f4cdd"
+        },
+        {
+          "name": "sorted-troves-2",
+          "address": "0x637344c0634626bb5d3c8fd5cc0fb332558778f8",
+          "role": "redemption-order",
+          "codeHash": "0xc51ccb0b1e60e81ff5f74a79b1b903c90ab2ba818c061cd8d976b897c8eca52e"
+        },
+        {
+          "name": "borrower-operations-2",
+          "address": "0x69e933767974fcd7cabeea976226783f4b952521",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0x548c2f538db4de263c1c8f984e007ae9c4fc5468534b6eb25e10948bdea8d8b9"
+        },
+        {
+          "name": "trove-nft-2",
+          "address": "0xec22e1dd649a98d2718cc2d9afb69dbf25ed3fa6",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0x33286fad1071deb8519f6842b8bf918f384fedde709d3a3cb53fb122ac41cb1e"
+        },
+        {
+          "name": "gas-pool-2",
+          "address": "0xedf7bc788f83e17d9b62da279db02b1bcc582262",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+        },
+        {
+          "name": "coll-surplus-pool-2",
+          "address": "0x08699bd503d890ce7fd7bf216d7a6e9da1a179e4",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0x594d859bf002207c35190bedcd2b567167ba1605546286ff6a908754b35bf24a"
+        },
+        {
+          "name": "weth-2",
+          "address": "0x4200000000000000000000000000000000000006",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+        },
+        {
+          "name": "interest-router-2",
+          "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+        },
+        {
+          "name": "eth-usd-oracle-3",
+          "address": "0x021d31211f81bc37ed7c9d535380cfaddd62c111",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-3",
+          "address": "0x4b9188dcb11c73b62e49e10791ebc276a2a66fc5",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x4cdb78872a01897ae8c3de14dde2de62eb78ef4cb1a584c52a433b69f2825c86"
+        },
+        {
+          "name": "secondary-oracle-3",
+          "address": "0xb15fb0fe60b20689390f8306dedebc608ae1ff3d",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "secondary-oracle-implementation-3",
+          "address": "0xc1b881e528cf9b3ea4838a327fa0104f49da1489",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x8865f2d5b5d2e904d8e17bdf71fd105f7ed198900ec6fb6bb10971a6217da0eb"
+        },
+        {
+          "name": "collateral-token-3",
+          "address": "0x92a7aee8afaa71ba0a9cc04a3dbe1f34237c33e0",
+          "role": "branch-collateral",
+          "codeHash": "0xf11ac24a06c48272aea7f0b069a80a581425a40fb2dda5fbd2e1b553d90de3d5"
+        },
+        {
+          "name": "addresses-registry-3",
+          "address": "0x1fdea10dc1f6ff27ed9881bdf464fe070dda6f76",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xb0a685fb22e858ffc522c63a887a76283c082b38de6a8c3d25b10225a2ad6aa4"
+        },
+        {
+          "name": "trove-manager-3",
+          "address": "0x835b04eefbb0e32d8f75cfe96acb527a42f1a0d9",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x0317d6c5f7a2d866db157ccc6a2ca6a6d1f8a66a019818cc7b6c6a0759157fc2"
+        },
+        {
+          "name": "stability-pool-3",
+          "address": "0x6bd55dd953507641c84a03956760f83d29d65726",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0x164195d0c2d06c9e4a47e508caf059cb3f748684bd12e198a2ad17d0f265a274"
+        },
+        {
+          "name": "price-feed-3",
+          "address": "0x9e191d9f3f3c138c81753acf6f4ec32e84daa89e",
+          "role": "protocol-oracle",
+          "codeHash": "0xd2cad96079007d34a22091269db9a09d7786967256f99d1e789611d8d6ef7baf"
+        },
+        {
+          "name": "active-pool-3",
+          "address": "0xcaa72df531554087318eaf24646958500668b230",
+          "role": "protocol-accounting",
+          "codeHash": "0x3a30f669459e6b3b3015dd564fbc4d25c77e9a05a4b766e6f6ebb6d108d51618"
+        },
+        {
+          "name": "default-pool-3",
+          "address": "0x2019453c36c7272bdea78a0901d448595d8127d2",
+          "role": "redistribution-accounting",
+          "codeHash": "0xd2cf6778816edd886cf1921ab0fb0534d8e38ef6871dedaffb33b874e4642535"
+        },
+        {
+          "name": "sorted-troves-3",
+          "address": "0xe55530a4205ec2eda84adf9f5efb2f456d5cb721",
+          "role": "redemption-order",
+          "codeHash": "0x91d916776dd94ec9e2007976f4835ee095dcad31af13a7a5f61993f579fd239f"
+        },
+        {
+          "name": "borrower-operations-3",
+          "address": "0xb9a3c82486d0b6d72dec55fcc9192af09aaa393b",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0x5303ecac158abdeb8f356539c92610aaf307b23e43dfed88fa36916562fcf95a"
+        },
+        {
+          "name": "trove-nft-3",
+          "address": "0x9bac1f53bb7d309df424f16ee8a0bbb5803b9776",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0x33d9d1b13e4b881f77259103cf5859f2dc2e47570f2180b2678f0ca36747e07a"
+        },
+        {
+          "name": "gas-pool-3",
+          "address": "0x503fef97e449d0db569155d8a1408717ee05d363",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+        },
+        {
+          "name": "coll-surplus-pool-3",
+          "address": "0xeddcfb454f8756e992601666df5adb3389ef15e4",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0xc7fd318822aa6da3a716c13c6875aa1f7019d70988ea4d7606a69faac4727777"
+        },
+        {
+          "name": "weth-3",
+          "address": "0x4200000000000000000000000000000000000006",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+        },
+        {
+          "name": "interest-router-3",
+          "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+        },
+        {
+          "name": "eth-usd-oracle-4",
+          "address": "0x77003c51b6febe7b88d1215004b91d4d3493fa30",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-4",
+          "address": "0x5ab26742abe7c904ddf35b4cae288eb4e4a36df2",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x8e5954f999e4aa765edefb7e1b0a35ca199c2275ce0c3c5bd7ed50940111e6ff"
+        },
+        {
+          "name": "secondary-oracle-4",
+          "address": "0xbe3efb4209ee6962c309e3ce8650d54b326d9cd3",
+          "role": "oracle-source",
+          "codeHash": "0x6a262fa9116d19f33c6b843c58c22f687293b75052171cfe58d05ba51365c3b1"
+        },
+        {
+          "name": "secondary-oracle-implementation-4",
+          "address": "0x9823fffe5ff8aaaa142dd6a398e501d49aaae9d9",
+          "role": "oracle-source-implementation",
+          "codeHash": "0xf22a5ad1ad14e9b6ed9b0e371c9ca75d1e1efe35568933f5af097343f414720c"
+        },
+        {
+          "name": "collateral-token-4",
+          "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
+          "role": "branch-collateral",
+          "codeHash": "0x8cd2f08c7ee9e6ab6e0180e8d6cb0613bbd54d2c4ae2ecdcaddfcdd9a226215b"
+        },
+        {
+          "name": "addresses-registry-4",
+          "address": "0x98f5ddda4c0250966a446d39167d0bfb8e4ca1b6",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xe7751391facfccceb4e24d8ac8b1b54b3e55a8b41d5a0e188bd6189f75fe5f0d"
+        },
+        {
+          "name": "trove-manager-4",
+          "address": "0x482de97e667330afba99f8ced527118aec66f15d",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x363d37d348f5676fa540db901a286b5f476c285236f0c6cfc01b1af196000a73"
+        },
+        {
+          "name": "stability-pool-4",
+          "address": "0x25afbb09d9804482ed8e24295be4a12704fe93ea",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0xc6e9460fdf3aa46f3b594465d0b4fbe4a27c2b2b8957283b8df71e65e87e8109"
+        },
+        {
+          "name": "price-feed-4",
+          "address": "0x23bb111e94ec68009da6b8fc50c19628a972b9e0",
+          "role": "protocol-oracle",
+          "codeHash": "0x126bcdb4430bcf77e3e9ad5e111dd20c2ab2cc1c0eef9efd9c4ccab2286cf8a9"
+        },
+        {
+          "name": "active-pool-4",
+          "address": "0xddac84ab417677f553cced8ababf497226112218",
+          "role": "protocol-accounting",
+          "codeHash": "0x41453918ea711d056566592c6092375f1c3ee91536d0d4687d72ca5e8f617b9c"
+        },
+        {
+          "name": "default-pool-4",
+          "address": "0xc8eb254aabd8a64193fea55aac36087393baf81b",
+          "role": "redistribution-accounting",
+          "codeHash": "0xd71e1c2268e5170c31c66318964fa05d974bea103a031ef8fc3db1150cc24f9d"
+        },
+        {
+          "name": "sorted-troves-4",
+          "address": "0x2792304889f35b60ccd79c3e173837bc6ec3ab44",
+          "role": "redemption-order",
+          "codeHash": "0x8b2837d637438aec533b93940bcdae5d85e669fc799a5aa88299008687d42cfa"
+        },
+        {
+          "name": "borrower-operations-4",
+          "address": "0xfa6e7e44e538b2cf7d73720b2b1942ab28abd1d5",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0xf0c72011594a373da689433929a25a981c8b22914e27bdadb69a772b94b7a7d7"
+        },
+        {
+          "name": "trove-nft-4",
+          "address": "0x2c3a69fe04c976a05e72033ac2433bcfaa15b68a",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0x85f16e52509dae287547f6d05b49bfa70a101662a29a6e5b60a527d930b78af3"
+        },
+        {
+          "name": "gas-pool-4",
+          "address": "0x4ad0d908d81c8b3f2d25ee29a1b01b31bee781bd",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0x24ebfae8aca0880567e376c82dea5d9cf19b745653fef806f97d13bb4ca05f6b"
+        },
+        {
+          "name": "coll-surplus-pool-4",
+          "address": "0x2d63ae9808cfabdab5cf6aa0202683726e46310f",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0xfef268801402fd5451967fb688fe0403cba596e0e843dc1b242f53bc8503cab3"
+        },
+        {
+          "name": "weth-4",
+          "address": "0x4200000000000000000000000000000000000006",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0x8a3a1f6a9f9dce633117adee5b458245835a8645a8c8726a26382a4622508b1c"
+        },
+        {
+          "name": "interest-router-4",
+          "address": "0x519ca17dae2e2a23396ebec12da1f645accec196",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+        }
+      ]
+    },
+    {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-07-16-block-25546976-shock-coverage.json",
       "journalSha256": "51bcb1b5c177ad7b31ff0faab0b055b300edc7ea30be86c0f318ab9fe4056751",
       "assetId": "bold-liquity",
@@ -15471,6 +16107,414 @@
       ]
     },
     {
+      "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-09-11-block-25953096-shock-coverage.json",
+      "journalSha256": "56a71b0c39cb1e36e300afa616c3a9a290541a561595d013166b86f94ae321e2",
+      "assetId": "bold-liquity",
+      "archetype": "cdp",
+      "family": "liquity-v2-shock-v1",
+      "applicability": "measured",
+      "failureReason": null,
+      "complete": true,
+      "blockers": [],
+      "exactReplayPassed": true,
+      "replayVerification": {
+        "attestationPath": "shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json",
+        "attestedAt": "2026-09-11",
+        "toolPath": "scripts/maintenance/measure-cdp-shock-coverage.ts",
+        "toolVersion": "1",
+        "mode": "offline-byte-identical",
+        "callsConsumed": 761,
+        "codePinsConsumed": 56
+      },
+      "block": {
+        "number": 25953096,
+        "hash": "0x93b5af0e7b1a6678e934cf8d3d1226a4947b0efd37f548a546856badddf0615a",
+        "timestampUnix": 1789116887,
+        "timestampIso": "2026-09-11T08:54:47.000Z"
+      },
+      "sourcePin": {
+        "repository": "https://github.com/liquity/bold",
+        "commit": "c8a5a4ee2e9dc024905856b6698a77d849c68c7e",
+        "liquidationContractPath": "contracts/src/TroveManager.sol"
+      },
+      "shockPolicy": {
+        "scoreShockFractionPpm": 500000,
+        "sensitivityShockFractionsPpm": [
+          400000,
+          500000,
+          600000,
+          750000
+        ],
+        "debtReconciliationTolerancePpm": 1000
+      },
+      "measuredFacts": {
+        "applicability": "measured",
+        "failureReason": null,
+        "stressShockFraction": 0.5,
+        "stressLiquidatableDebt": "15233565395984128595024940",
+        "stressPoolOffsetDebt": "11730761050827606483830615",
+        "stressLiquidationCoverageRatio": 0.770060110413,
+        "branchContributions": [
+          {
+            "branchIndex": 0,
+            "stressLiquidatableDebt": "4720906705876599400791559",
+            "stressPoolOffsetDebt": "4720906705876599400791559",
+            "stressLiquidationCoverageRatio": 1
+          },
+          {
+            "branchIndex": 1,
+            "stressLiquidatableDebt": "10499032276166729010267933",
+            "stressPoolOffsetDebt": "6996227931010206899073608",
+            "stressLiquidationCoverageRatio": 0.666368837334
+          },
+          {
+            "branchIndex": 2,
+            "stressLiquidatableDebt": "13626413940800183965448",
+            "stressPoolOffsetDebt": "13626413940800183965448",
+            "stressLiquidationCoverageRatio": 1
+          }
+        ]
+      },
+      "codePins": [
+        {
+          "name": "bold-token",
+          "address": "0x6440f144b7e50d6a8439336510312d2f54beb01d",
+          "role": "token",
+          "codeHash": "0xfee79b645b7275fbcb4e4891bb08f7c881e01378af3ecd74fb4dc19c47750d21"
+        },
+        {
+          "name": "collateral-registry",
+          "address": "0xf949982b91c8c61e952b3ba942cbbfaef5386684",
+          "role": "branch-enumerator",
+          "codeHash": "0x5478757832338027668465ab4e77c00e8dec71934941e18e49b52e6b572ed3f5"
+        },
+        {
+          "name": "eth-usd-oracle-0",
+          "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+          "role": "oracle-source",
+          "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-0",
+          "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+        },
+        {
+          "name": "collateral-token-0",
+          "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+          "role": "branch-collateral",
+          "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+        },
+        {
+          "name": "addresses-registry-0",
+          "address": "0x20f7c9ad66983f6523a0881d0f82406541417526",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0x5b2ea1e488451dfc36467287b48ca79a5297291567f483dcf95365ee28daaa5a"
+        },
+        {
+          "name": "trove-manager-0",
+          "address": "0x7bcb64b2c9206a5b699ed43363f6f98d4776cf5a",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x72d836bd8f8f2ea21eb31074bea3b8410f360e59fc9e00edafd2f0054b71a9fa"
+        },
+        {
+          "name": "stability-pool-0",
+          "address": "0x5721cbbd64fc7ae3ef44a0a3f9a790a9264cf9bf",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0x777b794d22f95d7db3d801c825afc8b57af074a9ab7c7af5876625e120ddaa39"
+        },
+        {
+          "name": "price-feed-0",
+          "address": "0xcc5f8102eb670c89a4a3c567c13851260303c24f",
+          "role": "protocol-oracle",
+          "codeHash": "0x584703b70ea8df7b1d0971cb69aa6751747735ffa110f50d6645cf113387fb8c"
+        },
+        {
+          "name": "active-pool-0",
+          "address": "0xeb5a8c825582965f1d84606e078620a84ab16afe",
+          "role": "protocol-accounting",
+          "codeHash": "0xdc859816c5ad16349bc6f0a17016db431648ab0c7f5fe8b6e7ece0a22bbe6dea"
+        },
+        {
+          "name": "default-pool-0",
+          "address": "0xd4558240d50c2e219a21c9d25afd513bb6e5b1a0",
+          "role": "redistribution-accounting",
+          "codeHash": "0x6b36badf295a64cdb794399abeaea82fabfd6f606375ce85a2cdb7649aa9de1f"
+        },
+        {
+          "name": "sorted-troves-0",
+          "address": "0xa25269e41bd072513849f2e64ad221e84f3063f4",
+          "role": "redemption-order",
+          "codeHash": "0x256861145481361c633e16675b57baea8c08cae4102afc26aa089db17584d26c"
+        },
+        {
+          "name": "borrower-operations-0",
+          "address": "0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0x447906ae6913c14793e4052ccd67808cbd38c373197b78aa752120e2f0bb2747"
+        },
+        {
+          "name": "trove-nft-0",
+          "address": "0x1a0fc0b843afd9140267d25d4e575cb37a838013",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0x927ae932def60a6f57961d072c1b601ac45f590fa950fa36ecfd9ff32103b22a"
+        },
+        {
+          "name": "gas-pool-0",
+          "address": "0x7b9ab3de4036cae51f1fa4ec0a2c2fd606bcf921",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0xac12f17a3db66a2b8414d5d856e37c619ef1c72cf59a0a0b08a7423d38ff8aee"
+        },
+        {
+          "name": "coll-surplus-pool-0",
+          "address": "0xedbe2509e502c0320d2e7f8b6746a49b4b50e2bf",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0xf1320038577d6fee7563370dfc62fa8f0e9e46c377dafa9091d6b97da0d70968"
+        },
+        {
+          "name": "weth-0",
+          "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+        },
+        {
+          "name": "interest-router-0",
+          "address": "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0x2a91933e7f237a53ed6f699474a7618e16623dbcebb26702e494a9ce6382d5ce"
+        },
+        {
+          "name": "eth-usd-oracle-1",
+          "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+          "role": "oracle-source",
+          "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-1",
+          "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+        },
+        {
+          "name": "secondary-oracle-1",
+          "address": "0xcfe54b5cd566ab89272946f602d76ea879cab4a8",
+          "role": "oracle-source",
+          "codeHash": "0xbd6f524cdc4268b6bd1bb6f77a8821faeea9c52ee9e0afa0b6d948ce82c966c2"
+        },
+        {
+          "name": "secondary-oracle-implementation-1",
+          "address": "0x26f196806f43e88fd27798c9e3fb8fdf4618240f",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+        },
+        {
+          "name": "rate-provider-1",
+          "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+          "role": "oracle-rate-provider",
+          "codeHash": "0x630181884786c962140041cffa3acffbf39d8c93bde1a62b7b55046e57400557"
+        },
+        {
+          "name": "collateral-token-1",
+          "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+          "role": "branch-collateral",
+          "codeHash": "0x630181884786c962140041cffa3acffbf39d8c93bde1a62b7b55046e57400557"
+        },
+        {
+          "name": "addresses-registry-1",
+          "address": "0x8d733f7ea7c23cbea7c613b6ebd845d46d3aac54",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xe9346fd91922f3d4d64279fde0a5d76c8337760e45149b5922417d5658b8d63f"
+        },
+        {
+          "name": "trove-manager-1",
+          "address": "0xa2895d6a3bf110561dfe4b71ca539d84e1928b22",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x64a22fbff8d3493d5f2e88c02a6f27c8a1c3b934dba2ae62df11b553b539e741"
+        },
+        {
+          "name": "stability-pool-1",
+          "address": "0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0xa7fc5531b7aa2f97ccff086ba951172a4deb6547c7427ff352ada086137dcbbf"
+        },
+        {
+          "name": "price-feed-1",
+          "address": "0xe7aa2ba9e086a379d3beb224098bc634a46e314e",
+          "role": "protocol-oracle",
+          "codeHash": "0x20f254eb11744222398d4bdc32a401f58bbf122ad375a4dbcc9c8d2634c7ac5d"
+        },
+        {
+          "name": "active-pool-1",
+          "address": "0x531a8f99c70d6a56a7cee02d6b4281650d7919a0",
+          "role": "protocol-accounting",
+          "codeHash": "0xeebae2c4062853955e4d00fab1b0900755c1b64df3e159b9e1ceeb26be70adde"
+        },
+        {
+          "name": "default-pool-1",
+          "address": "0xd796e1648526400386cc4d12fa05e5f11e6a22a1",
+          "role": "redistribution-accounting",
+          "codeHash": "0x11761d1e8a516ec55da92ed8b033097c30fe1f5ead4d176e52cc3d3fc5b6ef6f"
+        },
+        {
+          "name": "sorted-troves-1",
+          "address": "0x84eb85a8c25049255614f0536bea8f31682e86f1",
+          "role": "redemption-order",
+          "codeHash": "0x462dae7a1efc69ab98f9e91c92f5a925e0aebcc5256f7b78f59cc7c6f39e27ab"
+        },
+        {
+          "name": "borrower-operations-1",
+          "address": "0xa741a32f9dcfe6adba088fd0f97e90742d7d5da3",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0xae3cc62ddc87b1f972460bc05e6da66dcde3c222757c30b2a4c5f6122b53d251"
+        },
+        {
+          "name": "trove-nft-1",
+          "address": "0x857aecebf75f1012dc18e15020c97096aea31b04",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0x09ffd8bd34367164f932de6f86557c8ef7f34223fba6e2f352f1c100ee6ef439"
+        },
+        {
+          "name": "gas-pool-1",
+          "address": "0x8c44fba379d8a8608c0e29b2729deb75a981db1f",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0xac12f17a3db66a2b8414d5d856e37c619ef1c72cf59a0a0b08a7423d38ff8aee"
+        },
+        {
+          "name": "coll-surplus-pool-1",
+          "address": "0x36e6cbdf68f64cf00fc3a6c634a25be32dd0a235",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0xc3f9f82660d6b1e4fccbc618d25fb9d66f07eb743afb98bd7c4534ec8ad86e17"
+        },
+        {
+          "name": "weth-1",
+          "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+        },
+        {
+          "name": "interest-router-1",
+          "address": "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0x2a91933e7f237a53ed6f699474a7618e16623dbcebb26702e494a9ce6382d5ce"
+        },
+        {
+          "name": "eth-usd-oracle-2",
+          "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+          "role": "oracle-source",
+          "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+        },
+        {
+          "name": "eth-usd-oracle-implementation-2",
+          "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+        },
+        {
+          "name": "secondary-oracle-2",
+          "address": "0x536218f9e9eb48863970252233c8f271f554c2d0",
+          "role": "oracle-source",
+          "codeHash": "0xbd6f524cdc4268b6bd1bb6f77a8821faeea9c52ee9e0afa0b6d948ce82c966c2"
+        },
+        {
+          "name": "secondary-oracle-implementation-2",
+          "address": "0xc77904cd2ca0806cc3db0819e9630ff3e2f6093d",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x13f277b777164702d0b469a459d0cc7989958c7447e0c46e47c0575bbd3b5d2f"
+        },
+        {
+          "name": "rate-provider-2",
+          "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+          "role": "oracle-rate-provider",
+          "codeHash": "0xe34255314ec42825a6444800e6894665b8c74e84e9dd2f20866f7057812b3adf"
+        },
+        {
+          "name": "collateral-token-2",
+          "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+          "role": "branch-collateral",
+          "codeHash": "0xe34255314ec42825a6444800e6894665b8c74e84e9dd2f20866f7057812b3adf"
+        },
+        {
+          "name": "addresses-registry-2",
+          "address": "0x6106046f031a22713697e04c08b330ddaf3e8789",
+          "role": "parameter-and-graph-registry",
+          "codeHash": "0xe9346fd91922f3d4d64279fde0a5d76c8337760e45149b5922417d5658b8d63f"
+        },
+        {
+          "name": "trove-manager-2",
+          "address": "0xb2b2abeb5c357a234363ff5d180912d319e3e19e",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x64a22fbff8d3493d5f2e88c02a6f27c8a1c3b934dba2ae62df11b553b539e741"
+        },
+        {
+          "name": "stability-pool-2",
+          "address": "0xd442e41019b7f5c4dd78f50dc03726c446148695",
+          "role": "branch-local-committed-pool",
+          "codeHash": "0x524c5be28739d527168541b5444ea2fed9352a6c9ae2dbae0259833ea9444ced"
+        },
+        {
+          "name": "price-feed-2",
+          "address": "0x34f1e9c7dcc279ec70d3c4488eb2d80fba8b7b2b",
+          "role": "protocol-oracle",
+          "codeHash": "0x3da3a6ece7f18d93d85ed072e2272a4e88d999df891d3517cb8e7f32cd86b3b5"
+        },
+        {
+          "name": "active-pool-2",
+          "address": "0x9074d72cc82dad1e13e454755aa8f144c479532f",
+          "role": "protocol-accounting",
+          "codeHash": "0x733dc9cdcff48fd6b8d80760fbf2ad382203b96d28a889aa4129732a89f62bc5"
+        },
+        {
+          "name": "default-pool-2",
+          "address": "0x5cc5cefd034fdc4728d487a72ca58a410cddcd6b",
+          "role": "redistribution-accounting",
+          "codeHash": "0x6ef5b7c5a128829199bf602906f13a3b7b977d45aa603a382f461f61e89292e5"
+        },
+        {
+          "name": "sorted-troves-2",
+          "address": "0x14d8d8011df2b396ed2bbc4959bb73250324f386",
+          "role": "redemption-order",
+          "codeHash": "0x116ffff3a415ac0b3ababd6dde84006cd13c45c9317ada0de010d2bdd553c592"
+        },
+        {
+          "name": "borrower-operations-2",
+          "address": "0xe8119fc02953b27a1b48d2573855738485a17329",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0x3a695e4cfa4b57076fab2f93f4eeb75b7d902f9953c542718c53a1e2b79eab57"
+        },
+        {
+          "name": "trove-nft-2",
+          "address": "0x7ae430e25b67f19b431e1d1dc048a5bcf24c0873",
+          "role": "liquidation-owner-lookup",
+          "codeHash": "0xe5eb8e2d17276215074323cb5f9449f161ab622261548a1cfcc850de683b026c"
+        },
+        {
+          "name": "gas-pool-2",
+          "address": "0x45c81dce308389e1bee63ae30a04fb1e148dad41",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0xac12f17a3db66a2b8414d5d856e37c619ef1c72cf59a0a0b08a7423d38ff8aee"
+        },
+        {
+          "name": "coll-surplus-pool-2",
+          "address": "0xba4a2bd8b76df84cac98eba3f4b967d8423192bf",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0xec13cbc666728b0a1842ed11bf17e33c5aff1c636e6ace30ff10226edf832063"
+        },
+        {
+          "name": "weth-2",
+          "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+          "role": "liquidation-gas-compensation-token",
+          "codeHash": "0xd0a06b12ac47863b5c7be4185c2deaad1c61557033f56c7d4ea74429cbb25e23"
+        },
+        {
+          "name": "interest-router-2",
+          "address": "0x807def5e7d057df05c796f4bc75c3fe82bd6eee1",
+          "role": "liquidation-interest-minting",
+          "codeHash": "0x2a91933e7f237a53ed6f699474a7618e16623dbcebb26702e494a9ce6382d5ce"
+        }
+      ]
+    },
+    {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2021-05-19-block-12464949-shock-coverage.json",
       "journalSha256": "57c4df5ebea77928fabce5ce262ce8a1097e7562e0b70490a823793311328089",
       "assetId": "lusd-liquity",
@@ -19527,6 +20571,150 @@
         "hash": "0x62851cac8b31d9287b259a603ba3c33585a2da4340490ea69d8fb83282a5bf23",
         "timestampUnix": 1788422615,
         "timestampIso": "2026-09-03T08:03:35.000Z"
+      },
+      "sourcePin": {
+        "repository": "https://github.com/liquity/dev",
+        "commit": "5174ecd0da4842157aba989499200d690b7e374f",
+        "liquidationContractPath": "packages/contracts/contracts/TroveManager.sol"
+      },
+      "shockPolicy": {
+        "scoreShockFractionPpm": 500000,
+        "sensitivityShockFractionsPpm": [
+          400000,
+          500000,
+          600000,
+          750000
+        ],
+        "debtReconciliationTolerancePpm": 1000
+      },
+      "measuredFacts": {
+        "applicability": "measured",
+        "failureReason": null,
+        "stressShockFraction": 0.5,
+        "stressLiquidatableDebt": "0",
+        "stressPoolOffsetDebt": "0",
+        "stressLiquidationCoverageRatio": 1,
+        "branchContributions": [
+          {
+            "branchIndex": 0,
+            "stressLiquidatableDebt": "0",
+            "stressPoolOffsetDebt": "0",
+            "stressLiquidationCoverageRatio": 1
+          }
+        ]
+      },
+      "codePins": [
+        {
+          "name": "lusd-token",
+          "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+          "role": "token",
+          "codeHash": "0xa607f4c8379ffb91323184b39d374287ea702b699648610ba87b29fd4f9b00a1"
+        },
+        {
+          "name": "trove-manager",
+          "address": "0xa39739ef8b0231dbfa0dcda07d7e29faabcf4bb2",
+          "role": "liquidation-state-machine",
+          "codeHash": "0x33404f55d90f42f5d4684d3eb52d4afc7ee41fd86f9a0ff9c0afcf0af0a410bb"
+        },
+        {
+          "name": "stability-pool",
+          "address": "0x66017d22b0f8556afdd19fc67041899eb65a21bb",
+          "role": "committed-pool",
+          "codeHash": "0x9c3b21a3a97ad953c529831bb02b0fcd0ff03fc43054bac66a528702025d5bfe"
+        },
+        {
+          "name": "price-feed",
+          "address": "0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
+          "role": "protocol-oracle",
+          "codeHash": "0x8c867f65098a2714f2a6f57ea929da0a60a84813e837e31280f2ee3fa6cd92cd"
+        },
+        {
+          "name": "sorted-troves",
+          "address": "0x8fdd3fbfeb32b28fb73555518f8b361bcea741a6",
+          "role": "liquidation-order",
+          "codeHash": "0xde3f1240d86a227b42772efa8df3a6c96f7f1c6fce25106551d859fadf63d9b7"
+        },
+        {
+          "name": "active-pool",
+          "address": "0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f",
+          "role": "protocol-accounting",
+          "codeHash": "0x05861911a299411e528997f0d9078a5114bc29529befe386e53f639caab45705"
+        },
+        {
+          "name": "default-pool",
+          "address": "0x896a3f03176f05cfbb4f006bfcd8723f2b0d741c",
+          "role": "redistribution-accounting",
+          "codeHash": "0x8c5f0a005c7b308aff2fd2de3ee2f1f2e35c3f03c10d797391536668c4eea5b4"
+        },
+        {
+          "name": "borrower-operations",
+          "address": "0x24179cd81c9e782a4096035f7ec97fb8b783e007",
+          "role": "liquidation-state-cleanup",
+          "codeHash": "0xcbe65d5fc2c48608b31fc5c0b97f3b0c4853cdf3b20f681995eba3e44e51be77"
+        },
+        {
+          "name": "gas-pool",
+          "address": "0x9555b042f969e561855e5f28cb1230819149a8d9",
+          "role": "liquidation-gas-compensation",
+          "codeHash": "0x78721f13761f7378853c4a5bcc87ddbd38d95d06941d0fc0c54d73b12e00b746"
+        },
+        {
+          "name": "coll-surplus-pool",
+          "address": "0x3d32e8b97ed5881324241cf03b2da5e2ebce5521",
+          "role": "liquidation-collateral-surplus",
+          "codeHash": "0x7d5494b64358562eff75a949c075ce83e207406e7eca114e4cd187079e0aa01e"
+        },
+        {
+          "name": "chainlink-price-aggregator",
+          "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+          "role": "oracle-source",
+          "codeHash": "0x4b79b5c8aee6da0f7b393e8b53e6265ef7320a1d16184c65bd3841b5aa3d700d"
+        },
+        {
+          "name": "chainlink-price-aggregator-implementation",
+          "address": "0x7d4e742018fb52e48b08be73d041c18b21de6fb5",
+          "role": "oracle-source-implementation",
+          "codeHash": "0x16f41184f797cb8f8918680df0ebf2a97cc3192aa6b104615f61096fc674f2aa"
+        },
+        {
+          "name": "tellor-caller",
+          "address": "0xad430500ecda11e38c9bcb08a702274b94641112",
+          "role": "oracle-fallback",
+          "codeHash": "0x5002b4c59dee316a2410f60a901d2d5077878ac18daa0be7e5bfd138511e845f"
+        },
+        {
+          "name": "tellor-oracle",
+          "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+          "role": "oracle-fallback-source",
+          "codeHash": "0x18df49952ae206a293436515440bff85ba7a87d1ddf9ab0aab4e1fba63c11fbb"
+        }
+      ]
+    },
+    {
+      "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-09-11-block-25953096-shock-coverage.json",
+      "journalSha256": "52471c8bd25aedaef24169d729c2d0740d2c1e962e948ccf583038b59389cd2d",
+      "assetId": "lusd-liquity",
+      "archetype": "cdp",
+      "family": "liquity-v1-shock-v1",
+      "applicability": "measured",
+      "failureReason": null,
+      "complete": true,
+      "blockers": [],
+      "exactReplayPassed": true,
+      "replayVerification": {
+        "attestationPath": "shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json",
+        "attestedAt": "2026-09-11",
+        "toolPath": "scripts/maintenance/measure-cdp-shock-coverage.ts",
+        "toolVersion": "1",
+        "mode": "offline-byte-identical",
+        "callsConsumed": 244,
+        "codePinsConsumed": 14
+      },
+      "block": {
+        "number": 25953096,
+        "hash": "0x93b5af0e7b1a6678e934cf8d3d1226a4947b0efd37f548a546856badddf0615a",
+        "timestampUnix": 1789116887,
+        "timestampIso": "2026-09-11T08:54:47.000Z"
       },
       "sourcePin": {
         "repository": "https://github.com/liquity/dev",

--- a/shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json
+++ b/shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json
@@ -6,7 +6,7 @@
     "version": "1",
     "mode": "offline-byte-identical"
   },
-  "attestedAt": "2026-09-03",
+  "attestedAt": "2026-09-11",
   "attestations": [
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bd-basedollar/2026-08-21-block-50259336-shock-coverage.json",
@@ -70,6 +70,14 @@
       "attestedAt": "2026-09-03",
       "exactReplayPassed": true,
       "callsConsumed": 245,
+      "codePinsConsumed": 92
+    },
+    {
+      "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bd-basedollar/2026-09-11-block-51163570-shock-coverage.json",
+      "journalSha256": "9af131c08b78ce4e14c0092cb4875e314429826de768b25118e54155aa723282",
+      "attestedAt": "2026-09-11",
+      "exactReplayPassed": true,
+      "callsConsumed": 248,
       "codePinsConsumed": 92
     },
     {
@@ -278,6 +286,14 @@
       "attestedAt": "2026-09-03",
       "exactReplayPassed": true,
       "callsConsumed": 743,
+      "codePinsConsumed": 56
+    },
+    {
+      "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-09-11-block-25953096-shock-coverage.json",
+      "journalSha256": "56a71b0c39cb1e36e300afa616c3a9a290541a561595d013166b86f94ae321e2",
+      "attestedAt": "2026-09-11",
+      "exactReplayPassed": true,
+      "callsConsumed": 761,
       "codePinsConsumed": 56
     },
     {
@@ -510,6 +526,14 @@
       "attestedAt": "2026-09-03",
       "exactReplayPassed": true,
       "callsConsumed": 250,
+      "codePinsConsumed": 14
+    },
+    {
+      "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-09-11-block-25953096-shock-coverage.json",
+      "journalSha256": "52471c8bd25aedaef24169d729c2d0740d2c1e962e948ccf583038b59389cd2d",
+      "attestedAt": "2026-09-11",
+      "exactReplayPassed": true,
+      "callsConsumed": 244,
       "codePinsConsumed": 14
     }
   ]


### PR DESCRIPTION
Automated shock-coverage refresh for `lusd-liquity`, `bold-liquity`, and `bd-basedollar`. Every journal in this PR replayed byte-identically offline before the registry was regenerated.

**Merge promptly.** The V9 CDP freshness bound is 72h measured from the pinned block timestamp, not from merge time. Past it the engine fails closed to legacy LCR and LUSD drops to `unsafe-backing:high`, taking BOLD's and BD's ratings with it.

See [docs/process/shock-coverage-refresh.md](../blob/main/docs/process/shock-coverage-refresh.md).
