### PR TITLE
chore(ci): bump codeql-action to v4.37.9 and zizmor-action to v0.6.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,20 @@ updates:
       default-days: 7
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    ignore:
+      # actions/cache is also pinned inside .github/actions/setup-workspace
+      # (restore + cache), which Dependabot does not scan, so a workflow-only
+      # major bump of cache/save would split the restore/save pair across
+      # majors. Bump all three together by hand.
+      - dependency-name: "actions/cache"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "actions/cache/save"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "actions/cache/restore"
+        update-types:
+          - "version-update:semver-major"
     groups:
       # Dependabot treats each `uses:` path as its own dependency, so a
       # multi-step action such as github/codeql-action/{init,analyze}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,8 +37,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
-      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+      - uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3


### PR DESCRIPTION
Takes Dependabot's grouped actions PR #1079 minus its `actions/cache/save` v5.0.5→v6.1.0 hunk.

The `restore` and `cache` steps are pinned inside the composite `.github/actions/setup-workspace`, which Dependabot's github-actions ecosystem does not scan, so bumping only the workflow-side `save` half would split the restore/save pair across majors on the same cache keys. `actions/cache*` majors are now ignored for the workflows ecosystem; bump all three by hand together when moving to v6.