### PR TITLE
fix(live-reserves): follow-ups from the first post-deploy reserve run (BRLA Notion host, exact-threshold rounding)

### DIFF
--- a/shared/data/stablecoins/coins/brla-brla-digital.json
+++ b/shared/data/stablecoins/coins/brla-brla-digital.json
@@ -99,7 +99,8 @@
       "profile": "brla-v1",
       "indexHost": "brladigital.notion.site",
       "reportHosts": [
-        "file.notion.so"
+        "file.notion.so",
+        "file.notion.com"
       ]
     }
   },

--- a/worker/src/cron/reserve-adapters/__tests__/helpers.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/helpers.test.ts
@@ -511,6 +511,22 @@ describe("buildCoverageShortfallWarnings", () => {
       thresholdRatio: 0.99,
     })).toHaveLength(1);
   });
+
+  it("treats binary rounding just under an exact threshold as covered", () => {
+    // asUSDF in prod: backing / (supply * exchangePrice) = 0.9999999999999999.
+    expect(buildCoverageShortfallWarnings({
+      code: "reserve-undercollateralized",
+      message: (pct) => `${pct}%`,
+      coverageRatio: 0.9999999999999999,
+      thresholdRatio: 1,
+    })).toEqual([]);
+    expect(buildCoverageShortfallWarnings({
+      code: "reserve-undercollateralized",
+      message: (pct) => `${pct}%`,
+      coverageRatio: 0.99999,
+      thresholdRatio: 1,
+    })).toHaveLength(1);
+  });
 });
 
 describe("parseTimestampLikeToUnixSeconds", () => {

--- a/worker/src/cron/reserve-adapters/slice-math.ts
+++ b/worker/src/cron/reserve-adapters/slice-math.ts
@@ -406,13 +406,18 @@ interface CoverageShortfallWarningOptions {
   thresholdRatio?: number;
 }
 
+/** Absorbs binary rounding in assets ÷ liability so an exact 1.0 coverage
+ *  computed from bigint-scaled inputs (0.9999999999999999) cannot degrade
+ *  against a `thresholdRatio` of 1. Any real shortfall is far larger. */
+const COVERAGE_RATIO_EPSILON = 1e-9;
+
 export function buildCoverageShortfallWarnings({
   code,
   message,
   coverageRatio,
   thresholdRatio = 0.995,
 }: CoverageShortfallWarningOptions): LiveReserveWarning[] {
-  if (coverageRatio == null || coverageRatio >= thresholdRatio) {
+  if (coverageRatio == null || coverageRatio >= thresholdRatio - COVERAGE_RATIO_EPSILON) {
     return [];
   }
   return [reserveDegradedWarning(code, message((coverageRatio * 100).toFixed(2)))];


### PR DESCRIPTION
Follow-ups from the 12:11 UTC `sync-live-reserves` run on the health-pass deploy (worker 6750a3d1). That run itself: errors 11 → 5, degraded 26 → 23, breakers 4 → 0, drift rows 7 → 0, score-grade 77.8% → 80.9%.

1. **BRLA**: with the input-kind fix live, `brla-independent-assurance` reaches Notion's `getSignedFileUrls` and fails closed with `signed URL host is not reviewed` — Notion issues signed downloads from `file.notion.com`; config only knew `file.notion.so`. Verified today that the PDF served from the new host is byte-identical to the reviewed manifest (SHA-256 `f64c71d9…`, 588268 bytes). Host added beside the old one; the hash pin still binds the artifact.
2. **asUSDF**: degraded with `net USDF backing covers 100.00% of asUSDF supply` — the ratio evaluates to 0.9999999999999999 from bigint-scaled inputs against `thresholdRatio: 1`. `buildCoverageShortfallWarnings` now absorbs a 1e-9 epsilon; regression case added.

Remaining post-run errors are transient upstreams (MegaUSD served an HTML interstitial; DefiLlama had no DOC price at 12:11 — both return correctly now) and should clear at 16:11.

Tests: brla, registry, stablecoins, helpers, astherus — all green.