### PR TITLE
chore(ci): pin the composite action's cache restore/cache steps to v5.1.0

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -92,7 +92,7 @@ runs:
 
     - if: ${{ inputs.static-cache == 'true' }}
       id: static-cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: |
           .cache/eslint
@@ -105,7 +105,7 @@ runs:
           static-cache-${{ runner.os }}-${{ steps.cache-key.outputs.node-key }}-
 
     - if: ${{ inputs.next-cache == 'true' }}
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: .next/cache
         key: next-cache-${{ runner.os }}-${{ steps.cache-key.outputs.node-key }}-${{ hashFiles('package-lock.json', 'next.config.ts') }}-${{ github.job }}${{ inputs.next-cache-save == 'true' && format('-{0}-{1}', github.run_id, github.run_attempt) || '' }}
@@ -115,7 +115,7 @@ runs:
           next-cache-${{ runner.os }}-${{ steps.cache-key.outputs.node-key }}-
 
     - if: ${{ inputs.browser-cache == 'true' }}
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ~/.cache/ms-playwright
         key: browser-cache-${{ runner.os }}-${{ steps.cache-key.outputs.node-key }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Keeps `actions/cache/restore` and `actions/cache` in `.github/actions/setup-workspace` on the same v5.1.0 release (`caa29612…`, tag verified against actions/cache) as the `cache/save` step #1086 moved, so the pair never drifts — the split dependabot cannot see because it does not scan composite actions.