### PR TITLE
feat(yield): reframe PYS as pay-for-risk and land on the Opportunistic band

### DIFF
--- a/docs/yield-intelligence.md
+++ b/docs/yield-intelligence.md
@@ -402,7 +402,9 @@ The monthly coverage audit now treats both `AUTO_LENDING_POOL_MAP` and `EXPLICIT
 
 ## Pharos Yield Score (PYS)
 
-Risk-adjusted ranking (0–100) that balances yield magnitude against source risk, stablecoin safety, and consistency.
+Risk-adjusted ranking (0–100) that balances yield magnitude against source risk, stablecoin safety, and consistency. PYS answers one question — *is this APY paying enough for the risk taken?* — so it is yield per unit of risk, not a recommendation and not a safety verdict. A D-grade coin can top the leaderboard when it pays a lot for a lot of risk (wTRY at ~38% APY sits beside USDC at ~4.7%). Every surface that names PYS carries that framing, and each row also shows the joint safety × yield **zone** described under Presentation Boundaries.
+
+Known limitation (not yet versioned): PYS starts from nominal `apy30d` and weights the benchmark spread at only `PYS_BENCHMARK_SPREAD_WEIGHT` (0.25), so rows pegged to high-rate currencies earn PYS credit for policy-rate compensation rather than real excess yield; wTRY's +1.3% over TLREF scores like a much larger USD spread. A spread-first variant is under evaluation as a separate methodology change.
 
 **Formula (`computePYS()` in `shared/lib/yield-scoring.ts`):**
 
@@ -623,6 +625,8 @@ Schedules are owned by `worker/wrangler.toml`, `shared/lib/cron-jobs.ts`, and `s
 - The stablecoin detail section is an at-a-glance summary; `/stablecoin/<id>/yield/` is the history-first workbench. The two surfaces must not duplicate whole panels.
 - Deep-link workbenches are runtime analysis surfaces and remain `noindex`; `/yield/` and stablecoin detail pages are the indexable surfaces.
 - PYS factor attribution neutralizes one factor at a time and recomputes PYS. Per-factor deltas are explanatory and need not sum to the final score.
+- Every row carries a zone chip derived from `resolveYieldZone()` in `src/lib/yield-scatter.ts`: safety `>= 60` × 30-day APY above the row's benchmark (falling back to the visible USD benchmark) yields `Sweet Spot`, `Danger Zone`, `Play It Safe`, or `Why Bother?`. Labels, descriptions, and static badge classes live in `shared/lib/classification.ts` and are shared with the scatter-plot quadrants; unscored rows or rows with no benchmark render no chip. The hero highlight context and the leaderboard PYS tooltip use the same vocabulary so a top-PYS low-grade row reads as well-paid risk, not as an endorsement.
+- `/yield/` lands on the Opportunistic risk band (`YIELD_LANDING_RISK_BUDGET`: safety `>= 50`, warnings hidden). The `risk` URL param selects a band (`conservative`, `balanced`, `opportunistic`, or `any` for no band); an absent param is the landing band. The band only fills risk-budget keys the URL leaves unset, so explicit `minSafety`, `depth`, `sourcePosture`, `sourceConfidence`, or `warnings` params always win. Clearing one of those keys from the filter controls pins `risk=any` and keeps the other band-derived keys explicit. View presets stack on the current filters (active when their override keys match; counts computed on the stacked filters), and the compare drawer always selects from the unbanded universe so a selected low-grade row never disappears.
 
 ### Validation
 

--- a/shared/lib/classification/badges.ts
+++ b/shared/lib/classification/badges.ts
@@ -165,6 +165,35 @@ export const YIELD_TYPE_STYLES: Record<YieldType, { badge: string; hex: string }
   "structured-tranche": { badge: "bg-rose-500/10 text-rose-700 dark:text-rose-400 border-rose-500/20", hex: "#e11d48" },
 };
 
+/**
+ * Joint safety × yield reading shared by the /yield scatter quadrants and the
+ * per-row zone chip. Split at safety 60 and the row's own benchmark rate.
+ * PYS says how well a row pays for its risk; the zone says whether that risk
+ * is one a reader should be taking at all.
+ */
+export type YieldZoneKey = "sweet-spot" | "danger-zone" | "play-it-safe" | "why-bother";
+
+export const YIELD_ZONE_LABELS: Record<YieldZoneKey, string> = {
+  "sweet-spot": "Sweet Spot",
+  "danger-zone": "Danger Zone",
+  "play-it-safe": "Play It Safe",
+  "why-bother": "Why Bother?",
+};
+
+export const YIELD_ZONE_DESCRIPTIONS: Record<YieldZoneKey, string> = {
+  "sweet-spot": "Safety 60+ and APY above its benchmark: paid to hold a safer coin.",
+  "danger-zone": "Safety below 60 with APY above its benchmark: well-paid risk, not a safe pick.",
+  "play-it-safe": "Safety 60+ but APY at or below its benchmark: safe, underpaid.",
+  "why-bother": "Safety below 60 and APY at or below its benchmark: risk without pay.",
+};
+
+export const YIELD_ZONE_STYLES: Record<YieldZoneKey, { badge: string }> = {
+  "sweet-spot": { badge: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/20" },
+  "danger-zone": { badge: "bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/30" },
+  "play-it-safe": { badge: "bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20" },
+  "why-bother": { badge: "bg-slate-500/10 text-slate-700 dark:text-slate-400 border-slate-500/20" },
+};
+
 /** Chart hex colors for blacklist stablecoin breakdown.
  *  Intentionally per-stablecoin brand colors — independent of chart-colors.ts tokens. */
 export const BLACKLIST_CHART_COLORS: Record<BlacklistStablecoin, string> = {

--- a/src/app/yield/client.test.tsx
+++ b/src/app/yield/client.test.tsx
@@ -163,6 +163,7 @@ describe("YieldClient", () => {
     { data: makeResponse(), isLoading: false, error: new Error("Refresh failed") },
   ])("waits for loaded error-free data before tracking an empty view (%#)", (pending) => {
     searchParamsMock.set("q", "zzzz-no-match");
+    searchParamsMock.set("risk", "any");
     const ready = useYieldRankingsSummaryMock();
     useYieldRankingsSummaryMock.mockReturnValue({ ...ready, ...pending });
     const { rerender } = render(<YieldClient />);
@@ -180,6 +181,7 @@ describe("YieldClient", () => {
       ...useYieldRankingsSummaryMock(),
       data: { ...makeResponse(), rankings: [] },
     });
+    searchParamsMock.set("risk", "any");
     render(<YieldClient />);
     expect(trackEventMock).toHaveBeenCalledWith("yield_zero_results", { active_filter_count: 0 });
   });
@@ -277,6 +279,7 @@ describe("YieldClient", () => {
       refetch: vi.fn(),
     });
 
+    searchParamsMock.set("risk", "any");
     render(<YieldClient />);
 
     const props = scatterPropsMock.mock.calls.at(-1)?.[0] as { rankings: unknown[] };
@@ -361,10 +364,25 @@ describe("YieldClient", () => {
 
     expect(params.get("peg")).toBe("USD");
     expect(params.get("q")).toBe("coin");
-    expect(params.get("minSafety")).toBe("80");
-    expect(params.get("depth")).toBe("hide-thin");
-    expect(params.get("sourcePosture")).toBe("clean");
-    expect(params.get("warnings")).toBe("hide");
+    expect(params.get("risk")).toBe("conservative");
+    expect(params.get("minSafety")).toBeNull();
+    expect(params.get("depth")).toBeNull();
+    expect(params.get("sourcePosture")).toBeNull();
     expect(params.get("sourceConfidence")).toBeNull();
+    expect(params.get("warnings")).toBeNull();
+  });
+
+  it("selecting the all risk-budget stop writes the neutral any param", () => {
+    render(<YieldClient />);
+
+    fireEvent.change(screen.getByRole("slider", { name: "Risk tolerance" }), {
+      target: { value: "3" },
+    });
+
+    const update = replaceParamsMock.mock.calls[0]?.[0] as (params: URLSearchParams) => void;
+    const params = new URLSearchParams(searchParamsMock);
+    update(params);
+
+    expect(params.get("risk")).toBe("any");
   });
 });

--- a/src/app/yield/page.tsx
+++ b/src/app/yield/page.tsx
@@ -10,13 +10,13 @@ import {
 import type { FaqItem } from "@/lib/faq";
 
 const desc =
-  "Compare risk-adjusted stablecoin yield rankings by APY, safety grade, source freshness, benchmark spread, venue risk, and Pharos Yield Score.";
+  "Compare stablecoin yields by APY, safety grade, source risk, and benchmark spread. The Pharos Yield Score asks one question: is this APY paying enough for the risk you take?";
 
 const FAQ_ITEMS = [
   {
     question: "What is the Pharos Yield Score (PYS)?",
     answer:
-      "The Pharos Yield Score (PYS) is a risk-adjusted yield metric scored 0-100 that balances yield magnitude against safety, benchmark context, source risk, and consistency. It starts from 30-day average APY, adds 25% of the row's benchmark spread, divides that effective yield by source-risk and safety-derived penalties, then applies a sustainability multiplier based on APY volatility over the same period. Higher-safety stablecoins and cleaner yield sources incur lower adjusted penalties, so moderate but durable yield can compete with riskier double-digit offers.",
+      "The Pharos Yield Score (PYS) answers one question: is this APY paying enough for the risk you take? It is yield per unit of risk on a 0-100 scale, not a recommendation and not a safety verdict. It starts from 30-day average APY, adds 25% of the row's benchmark spread, divides that effective yield by source-risk and safety-derived penalties, then applies a sustainability multiplier based on APY volatility over the same period. A D-grade stablecoin can post a high PYS because it pays a lot for a lot of risk; read PYS next to the Safety grade and the row's zone (Sweet Spot, Danger Zone, Play It Safe, Why Bother?) before acting on it.",
   },
   {
     question: "How are stablecoin yields sourced?",
@@ -26,7 +26,7 @@ const FAQ_ITEMS = [
   {
     question: "What does 'risk-adjusted' mean for stablecoin yield?",
     answer:
-      "Risk-adjusted yield accounts for the safety of the stablecoin issuing the yield, not just the raw APY. A stablecoin with a high safety grade (A or A+) receives a much lighter adjusted penalty in the PYS formula, so even a moderate APY can score well. Conversely, a risky stablecoin must offer meaningfully higher raw yield to achieve the same PYS, reflecting the extra risk borne by the holder.",
+      "Risk-adjusted yield accounts for the safety of the stablecoin issuing the yield, not just the raw APY. A stablecoin with a high safety grade (A or A+) receives a much lighter adjusted penalty in the PYS formula, so even a moderate APY can score well. Conversely, a risky stablecoin must offer meaningfully higher raw yield to achieve the same PYS, reflecting the extra risk borne by the holder. Risk-adjusted does not mean safe: a top PYS on a low-grade coin says the yield compensates the risk well, not that the risk is small.",
   },
   {
     question: "How do holder yield and lending opportunities differ?",
@@ -44,9 +44,9 @@ const FAQ_ITEMS = [
       "No. Depth is an explanatory lens for how much evidence backs the observed yield source, using venue size and related source-risk fields where available. It is not a fill-size estimate, execution quote, or guarantee that capital can enter or exit at the displayed APY.",
   },
   {
-    question: "Is PYS a guarantee or an additive score breakdown?",
+    question: "Is PYS a guarantee, a recommendation, or an additive score breakdown?",
     answer:
-      "No. PYS is a comparative ranking score built from historical APY, benchmark context, source-risk penalties, stablecoin safety penalties, and yield stability. Component explanations show why a row moved, but they are not guarantees and should not be read as independently additive promises of future return.",
+      "None of these. PYS is a comparative score built from historical APY, benchmark context, source-risk penalties, stablecoin safety penalties, and yield stability. It ranks how well each row pays for its risk; it does not endorse a row, and the leaderboard sorted by PYS is not a list of recommended coins. Component explanations show why a row moved, but they are not guarantees and should not be read as independently additive promises of future return.",
   },
 ] as const satisfies readonly FaqItem[];
 
@@ -79,7 +79,11 @@ const route = createClientFeaturePage({
       version: YIELD_METHODOLOGY_VERSION_LABEL,
       changelogPath: YIELD_METHODOLOGY_CHANGELOG_PATH,
     },
-    leadParagraphs: ["Stablecoin yield rankings that weigh every APY against safety and real-world benchmarks."],
+    leadParagraphs: [
+      "Stablecoin yield rankings that weigh every APY against safety and real-world benchmarks.",
+      "Two readings per row: Safety says how likely you are to lose money; PYS says how well the yield pays you for that chance. A high PYS on a D-grade coin is well-paid risk, not a safe pick. The page opens on the Opportunistic band (C+ safety, warnings hidden); widen the Risk tolerance slider to see everything.",
+    ],
+    leadFullWidth: true,
   },
   afterClient: (
     <>

--- a/src/components/__tests__/yield-leaderboard-controls.test.tsx
+++ b/src/components/__tests__/yield-leaderboard-controls.test.tsx
@@ -120,7 +120,7 @@ describe("YieldLeaderboardControls", () => {
 
     render(
       <YieldLeaderboardControls
-        viewModel={buildModel({ attention: "watchlist" }, new Set(["usdc-circle"]))}
+        viewModel={buildModel({ attention: "watchlist", risk: "any" }, new Set(["usdc-circle"]))}
         onFilterChange={onFilterChange}
         onClearFilters={vi.fn()}
         onApplyPreset={vi.fn()}

--- a/src/components/feature-page-shell.tsx
+++ b/src/components/feature-page-shell.tsx
@@ -15,6 +15,8 @@ export interface FeaturePageShellProps {
   };
   headerActions?: React.ReactNode;
   leadParagraphs?: readonly React.ReactNode[];
+  /** Let lead paragraphs span the container instead of the prose-width cap. */
+  leadFullWidth?: boolean;
   headerSupplement?: React.ReactNode;
   preface?: React.ReactNode;
   children: React.ReactNode;
@@ -30,6 +32,7 @@ export function FeaturePageShell({
   methodology,
   headerActions,
   leadParagraphs = [],
+  leadFullWidth = false,
   headerSupplement,
   preface,
   children,
@@ -71,7 +74,7 @@ export function FeaturePageShell({
           </p>
         )}
         {leadParagraphs.length > 0 ? (
-          <div className="max-w-4xl space-y-2">
+          <div className={leadFullWidth ? "space-y-2" : "max-w-4xl space-y-2"}>
             {leadParagraphs.map((paragraph, index) => (
               <p key={index} className={index === 0 ? "pharos-page-lead" : "pharos-lead"}>
                 {paragraph}

--- a/src/components/yield-instrument-board.tsx
+++ b/src/components/yield-instrument-board.tsx
@@ -9,6 +9,7 @@ import { MethodologyHint } from "@/components/methodology-hint";
 import { TablePagination, type TablePaginationProps } from "@/components/table-pagination";
 import { YieldWatchlistStar } from "@/components/yield-watchlist-star";
 import { YieldCohortChip } from "@/components/yield-cohort-chip";
+import { YieldZoneChip } from "@/components/yield-zone-chip";
 import {
   ApyRangeBar,
   YieldExpandedDetails,
@@ -286,6 +287,7 @@ function YieldInstrumentRowBase({
             <Badge variant="outline" className={`text-[10px] ${YIELD_TYPE_STYLES[row.yieldType]?.badge ?? ""}`}>
               {YIELD_TYPE_LABELS[row.yieldType] ?? row.yieldType}
             </Badge>
+            <YieldZoneChip safetyScore={safetyScore} apy30d={row.apy30d} benchmarkRate={benchmarkRate} />
             <YieldSignalsIndicator
               row={row}
               sourceRiskMaterial={sourceRiskMaterial}
@@ -582,7 +584,7 @@ export function YieldInstrumentBoard({
         <HeaderCell
           label="PYS"
           adornment={<MethodologyHint topic="pys" />}
-          title="Pharos Yield Score: risk-adjusted yield ranking"
+          title="Pharos Yield Score: is this APY paying enough for the risk? Yield per unit of risk, not a recommendation"
         />
         <HeaderCell label="Source" />
         <HeaderCell label="TVL" title="Total value locked in yield source" />

--- a/src/components/yield-leaderboard.tsx
+++ b/src/components/yield-leaderboard.tsx
@@ -30,6 +30,7 @@ import { isOpportunityDerivedSafety } from "@shared/lib/yield-opportunity-proven
 import { YIELD_TYPE_LABELS, YIELD_TYPE_STYLES } from "@shared/lib/classification";
 import { formatPercent, formatScore } from "@shared/lib/format";
 import { YieldCohortChip } from "@/components/yield-cohort-chip";
+import { YieldZoneChip } from "@/components/yield-zone-chip";
 import { YieldWhyPysStrip } from "@/components/yield-why-pys-strip";
 import {
   YieldRankChangeChip,
@@ -572,6 +573,7 @@ export function YieldMobileCard({
         <Badge variant="outline" className={`text-[10px] ${YIELD_TYPE_STYLES[row.yieldType]?.badge ?? ""}`}>
           {YIELD_TYPE_LABELS[row.yieldType] ?? row.yieldType}
         </Badge>
+        <YieldZoneChip safetyScore={safetyScore} apy30d={row.apy30d} benchmarkRate={row.benchmarkRate ?? riskFreeRate} />
         <MobileMetricPill>
           TVL{" "}
           <span className={tvlIsNative ? "text-muted-foreground" : "font-mono tabular-nums text-foreground"}>

--- a/src/components/yield-scatter-plot.tsx
+++ b/src/components/yield-scatter-plot.tsx
@@ -20,7 +20,7 @@ import { computeApyAxis, computeSafetyDomain, nudgeOverlaps, SAFETY_SCORE_THRESH
 import { getYieldBenchmarkDisplayLabel } from "@/lib/yield-benchmark";
 import { SEVERITY_TONE_CLASS } from "@/lib/severity-tone";
 import { cn } from "@/lib/utils";
-import { YIELD_TYPE_LABELS } from "@shared/lib/classification";
+import { YIELD_TYPE_LABELS, YIELD_ZONE_LABELS } from "@shared/lib/classification";
 import { YIELD_RISK_BUDGET_MIN_SAFETY } from "@/lib/yield-view-model";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { resolveCompactLogoSrc } from "@/lib/logo-variants";
@@ -77,7 +77,7 @@ const YIELD_SCATTER_QUADRANTS = [
     key: "sweet-spot",
     safetySide: "above-threshold",
     yieldSide: "above-benchmark",
-    label: "Sweet Spot",
+    label: YIELD_ZONE_LABELS["sweet-spot"],
     labelPosition: "insideTopRight",
     fill: CHART_GREEN,
     fillOpacity: 0.12,
@@ -86,7 +86,7 @@ const YIELD_SCATTER_QUADRANTS = [
     key: "danger-zone",
     safetySide: "below-threshold",
     yieldSide: "above-benchmark",
-    label: "Danger Zone",
+    label: YIELD_ZONE_LABELS["danger-zone"],
     labelPosition: "insideTopLeft",
     fill: CHART_RED,
     fillOpacity: 0.12,
@@ -95,7 +95,7 @@ const YIELD_SCATTER_QUADRANTS = [
     key: "play-it-safe",
     safetySide: "above-threshold",
     yieldSide: "below-benchmark",
-    label: "Play It Safe",
+    label: YIELD_ZONE_LABELS["play-it-safe"],
     labelPosition: "insideBottomRight",
     fill: CHART_BLUE,
     fillOpacity: 0.12,
@@ -104,7 +104,7 @@ const YIELD_SCATTER_QUADRANTS = [
     key: "why-bother",
     safetySide: "below-threshold",
     yieldSide: "below-benchmark",
-    label: "Why Bother?",
+    label: YIELD_ZONE_LABELS["why-bother"],
     labelPosition: "insideBottomLeft",
     fill: CHART_SLATE,
     fillOpacity: 0.07,

--- a/src/components/yield-zone-chip.tsx
+++ b/src/components/yield-zone-chip.tsx
@@ -1,0 +1,31 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { resolveYieldZone } from "@/lib/yield-scatter";
+import { YIELD_ZONE_DESCRIPTIONS, YIELD_ZONE_LABELS, YIELD_ZONE_STYLES } from "@shared/lib/classification";
+
+interface YieldZoneChipProps {
+  safetyScore: number | null;
+  apy30d: number;
+  benchmarkRate: number | null | undefined;
+  className?: string;
+}
+
+/**
+ * Row-level echo of the scatter-plot quadrant. Sits beside the yield-type
+ * badge so a top-PYS D-grade row reads "Danger Zone" on the same line as its
+ * score instead of looking like a recommendation.
+ */
+export function YieldZoneChip({ safetyScore, apy30d, benchmarkRate, className }: YieldZoneChipProps) {
+  const zone = resolveYieldZone(safetyScore, apy30d, benchmarkRate);
+  if (zone === null) return null;
+  return (
+    <Badge
+      variant="outline"
+      title={YIELD_ZONE_DESCRIPTIONS[zone]}
+      aria-label={`${YIELD_ZONE_LABELS[zone]}: ${YIELD_ZONE_DESCRIPTIONS[zone]}`}
+      className={cn("cursor-help text-[10px]", YIELD_ZONE_STYLES[zone].badge, className)}
+    >
+      {YIELD_ZONE_LABELS[zone]}
+    </Badge>
+  );
+}

--- a/src/components/yield/yield-client.tsx
+++ b/src/components/yield/yield-client.tsx
@@ -26,7 +26,9 @@ import {
   getActiveFilterSummaries,
   prepareYieldUniverse,
   RISK_BUDGET_FILTER_KEYS,
+  riskBudgetUrlValue,
   selectVisibleYieldRows,
+  YIELD_LANDING_RISK_BUDGET,
   YIELD_PRESET_SPECS,
   YIELD_RISK_BUDGET_SPECS,
   type YieldPresetKey,
@@ -35,6 +37,8 @@ import {
   type YieldViewModelRow,
 } from "@/lib/yield-view-model";
 import { buildStablecoinUrl } from "@shared/lib/urls";
+import { YIELD_ZONE_LABELS } from "@shared/lib/classification";
+import { resolveYieldZone } from "@/lib/yield-scatter";
 import { buildYieldStoryCallouts } from "@/lib/yield-story-callouts";
 import { trackEvent } from "@/lib/analytics";
 import { formatCurrency, formatPercent } from "@shared/lib/format";
@@ -144,12 +148,15 @@ function HeroHighlightRow({ label, logoSrc, name, symbol, value, unit, context, 
   );
 }
 
-function formatHeroRiskContext(row: YieldViewModelRow): string {
+function formatHeroRiskContext(row: YieldViewModelRow, riskFreeRate: number): string {
+  const zone = resolveYieldZone(row.safetyScore, row.apy30d, row.benchmarkRate ?? riskFreeRate);
   const safety = row.safetyGrade && row.safetyGrade !== "NR" ? `${row.safetyGrade} safety` : "Safety NR";
   const pys = row.pharosYieldScore !== null ? `PYS ${row.pharosYieldScore.toFixed(1)}` : "PYS NR";
   const posture = row.sourcePosture ? row.sourcePosture.replaceAll("-", " ") : "posture unknown";
   const warningCount = row.warningSignals.length;
-  return `${safety} · ${pys} · ${posture} · ${warningCount} warning${warningCount === 1 ? "" : "s"}`;
+  const parts = [safety, pys, posture, `${warningCount} warning${warningCount === 1 ? "" : "s"}`];
+  if (zone !== null) parts.unshift(YIELD_ZONE_LABELS[zone]);
+  return parts.join(" · ");
 }
 
 function YieldApiWarnings({ warnings }: { warnings: YieldRankingsSummaryResponse["warnings"] }) {
@@ -275,6 +282,7 @@ export function YieldClient() {
   const watchlist = useWatchlist();
   const urlParams = useMemo(
     () => ({
+      risk: searchParams.get("risk"),
       peg: searchParams.get("peg"),
       yieldType: searchParams.get("yieldType"),
       q: searchParams.get("q"),
@@ -302,7 +310,9 @@ export function YieldClient() {
       }),
     [data?.benchmarks, data?.provenance?.benchmark, data?.provenance?.benchmarks, urlParams, yieldUniverse],
   );
-  const comparisonRows = useMemo(() => selectVisibleYieldRows(yieldUniverse, {}), [yieldUniverse]);
+  // Compare/selection universe ignores the landing risk band so a selected
+  // D-grade row does not vanish from the drawer.
+  const comparisonRows = useMemo(() => selectVisibleYieldRows(yieldUniverse, { risk: riskBudgetUrlValue("all") }), [yieldUniverse]);
   const visibleRows = viewModel.visibleRows;
   const storyCallouts = useMemo(() => buildYieldStoryCallouts(visibleRows), [visibleRows]);
   const activeFilterSummaries = useMemo(() => getActiveFilterSummaries(viewModel), [viewModel]);
@@ -393,15 +403,38 @@ export function YieldClient() {
 
   const handleFilterChange = useCallback(
     (key: string, value: string) => {
-      setParam(key, value);
       const trackedValue = key === "q" ? (value.trim() ? "non-empty" : "empty") : value || "all";
+      const clearing = trackedValue === "all" || trackedValue === "empty";
+      if (key === "risk") {
+        // Whole-band move (empty-state "Show all risk levels"): drop every
+        // explicit band key so the requested band alone decides.
+        replaceParams((params) => {
+          for (const riskKey of RISK_BUDGET_FILTER_KEYS) params.delete(riskKey);
+          if (clearing) params.delete("risk");
+          else params.set("risk", value);
+        });
+      } else if (clearing && RISK_BUDGET_FILTER_KEYS.includes(key as (typeof RISK_BUDGET_FILTER_KEYS)[number])) {
+        // Deleting a risk-budget key alone would let the URL risk band re-fill
+        // it. Pin the band to neutral and keep the other band-derived keys
+        // explicit so only the cleared key relaxes.
+        replaceParams((params) => {
+          params.set("risk", riskBudgetUrlValue("all"));
+          for (const riskKey of RISK_BUDGET_FILTER_KEYS) {
+            const current = viewModel.normalizedParams[riskKey];
+            if (riskKey === key || current === null) params.delete(riskKey);
+            else params.set(riskKey, current);
+          }
+        });
+      } else {
+        setParam(key, value);
+      }
       trackEvent("yield_filter_changed", {
         filter_type: key,
         filter_value: trackedValue,
-        action: trackedValue === "all" || trackedValue === "empty" ? "cleared" : "applied",
+        action: clearing ? "cleared" : "applied",
       });
     },
-    [setParam],
+    [replaceParams, setParam, viewModel.normalizedParams],
   );
 
   const handleClearFilters = useCallback(() => {
@@ -455,10 +488,8 @@ export function YieldClient() {
         for (const paramKey of RISK_BUDGET_FILTER_KEYS) {
           params.delete(paramKey);
         }
-        for (const [paramKey, value] of Object.entries(spec.overrides)) {
-          if (value == null) continue;
-          params.set(paramKey, String(value));
-        }
+        if (key === YIELD_LANDING_RISK_BUDGET) params.delete("risk");
+        else params.set("risk", riskBudgetUrlValue(key));
       });
     },
     [replaceParams, viewModel.riskBudget.stops],
@@ -512,14 +543,14 @@ export function YieldClient() {
               topPysRow ? (
                 <span className="space-y-1">
                   <span className="block">
-                    Top risk-adjusted yield <span className="text-foreground/70">· {topPysRow.symbol}</span>
+                    Best-paid risk in view <span className="text-foreground/70">· {topPysRow.symbol}</span>
                   </span>
                   <span className="block text-[11px] font-normal text-muted-foreground">
-                    {formatHeroRiskContext(topPysRow)}
+                    {formatHeroRiskContext(topPysRow, data.riskFreeRate)}
                   </span>
                 </span>
               ) : (
-                "Top risk-adjusted yield"
+                "Best-paid risk in view"
               )
             }
             beamValue={
@@ -534,7 +565,7 @@ export function YieldClient() {
             }
             beamTitle={
               topPysRow && topPysRow.pharosYieldScore != null
-                ? `Best Pharos Yield Score in view: ${topPysRow.pharosYieldScore.toFixed(1)}`
+                ? `Best Pharos Yield Score in view: ${topPysRow.pharosYieldScore.toFixed(1)} — highest yield per unit of risk, not the safest coin`
                 : undefined
             }
             expand={{ href: "#data", label: "Jump to the full yield leaderboard" }}
@@ -550,7 +581,7 @@ export function YieldClient() {
                       symbol={exhibitTiles.topYield.symbol}
                       value={formatPercent(exhibitTiles.topYield.apy30d)}
                       unit="APY"
-                      context={formatHeroRiskContext(exhibitTiles.topYield)}
+                      context={formatHeroRiskContext(exhibitTiles.topYield, data.riskFreeRate)}
                       onClick={() => handleScrollToRow(exhibitTiles.topYield!.id)}
                     />
                   ) : null}
@@ -562,7 +593,7 @@ export function YieldClient() {
                       symbol={exhibitTiles.mostStable.symbol}
                       value={formatPercent(exhibitTiles.mostStable.apy30d)}
                       unit="APY"
-                      context={formatHeroRiskContext(exhibitTiles.mostStable)}
+                      context={formatHeroRiskContext(exhibitTiles.mostStable, data.riskFreeRate)}
                       onClick={() => handleScrollToRow(exhibitTiles.mostStable!.id)}
                     />
                   ) : null}
@@ -574,7 +605,7 @@ export function YieldClient() {
                       symbol={exhibitTiles.largestMarket.symbol}
                       value={formatCurrency(exhibitTiles.largestMarket.sourceTvlUsd!)}
                       unit="TVL"
-                      context={formatHeroRiskContext(exhibitTiles.largestMarket)}
+                      context={formatHeroRiskContext(exhibitTiles.largestMarket, data.riskFreeRate)}
                       onClick={() => handleScrollToRow(exhibitTiles.largestMarket!.id)}
                     />
                   ) : null}

--- a/src/lib/__tests__/yield-view-model.test.ts
+++ b/src/lib/__tests__/yield-view-model.test.ts
@@ -119,13 +119,13 @@ describe("buildYieldViewModel", () => {
   });
 
   it.each([
-    [{ peg: "non-usd" }, ["eurc-circle"]],
-    [{ yieldType: "lending-vault" }, ["eurc-circle"]],
-    [{ q: "eur" }, ["eurc-circle"]],
-    [{ warnings: "only" }, ["eurc-circle", "usdt-tether"]],
-    [{ sourceConfidence: "deterministic" }, ["eurc-circle"]],
-    [{ benchmark: "EUR" }, ["eurc-circle"]],
-    [{ opportunity: "holder-yield" }, ["eurc-circle"]],
+    [{ risk: "any", peg: "non-usd" }, ["eurc-circle"]],
+    [{ risk: "any", yieldType: "lending-vault" }, ["eurc-circle"]],
+    [{ risk: "any", q: "eur" }, ["eurc-circle"]],
+    [{ risk: "any", warnings: "only" }, ["eurc-circle", "usdt-tether"]],
+    [{ risk: "any", sourceConfidence: "deterministic" }, ["eurc-circle"]],
+    [{ risk: "any", benchmark: "EUR" }, ["eurc-circle"]],
+    [{ risk: "any", opportunity: "holder-yield" }, ["eurc-circle"]],
   ])("independently filters by %j", (filters, expected) => {
     const model = buildYieldViewModel(prepareYieldUniverse(rows, null), filters);
     expect(model.visibleRows.map((row) => row.id).sort()).toEqual(expected);
@@ -133,6 +133,7 @@ describe("buildYieldViewModel", () => {
 
   it("composes multiple current-payload filters with AND semantics", () => {
     const model = buildYieldViewModel(prepareYieldUniverse(rows, null), {
+      risk: "any",
       peg: "non-usd",
       yieldType: "lending-vault",
       q: "eur",
@@ -161,7 +162,7 @@ describe("buildYieldViewModel", () => {
       makeYieldRanking({ id: "fixed", symbol: "FIXED", yieldType: "fixed-yield" }),
       makeYieldRanking({ id: "tranche", symbol: "TRANCHE", yieldType: "structured-tranche" }),
     ];
-    const model = buildYieldViewModel(prepareYieldUniverse(opportunityRows, null), { opportunity: "lending-opportunity" });
+    const model = buildYieldViewModel(prepareYieldUniverse(opportunityRows, null), { risk: "any", opportunity: "lending-opportunity" });
 
     expect(model.visibleRows.map((row) => row.id).sort()).toEqual(["fixed", "lend", "tranche"]);
     expect(model.comparisonLabel).toBe("External opportunities");
@@ -172,7 +173,7 @@ describe("buildYieldViewModel", () => {
       { value: "lending-opportunity", label: "External opportunities", count: 3 },
     ]);
 
-    const trancheModel = buildYieldViewModel(prepareYieldUniverse(opportunityRows, null), { yieldType: "structured-tranche" });
+    const trancheModel = buildYieldViewModel(prepareYieldUniverse(opportunityRows, null), { risk: "any", yieldType: "structured-tranche" });
     expect(trancheModel.filters.yieldType).toBe("structured-tranche");
     expect(trancheModel.visibleRows.map((row) => row.id)).toEqual(["tranche"]);
     expect(trancheModel.comparisonLabel).toBe("Structured Tranche");
@@ -213,12 +214,12 @@ describe("buildYieldViewModel", () => {
   });
 
   it("excludes null safety and TVL only when minimum filters are set", () => {
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), {}).visibleRows.map((row) => row.id)).toContain("eurc-circle");
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any" }).visibleRows.map((row) => row.id)).toContain("eurc-circle");
 
-    const safetyFiltered = buildYieldViewModel(prepareYieldUniverse(rows, null), { minSafety: "70" });
+    const safetyFiltered = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", minSafety: "70" });
     expect(safetyFiltered.visibleRows.map((row) => row.id)).toEqual(["usdc-circle"]);
 
-    const tvlFiltered = buildYieldViewModel(prepareYieldUniverse(rows, null), { minTvl: "10000000" });
+    const tvlFiltered = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", minTvl: "10000000" });
     expect(tvlFiltered.visibleRows.map((row) => row.id)).toEqual(["usdt-tether"]);
   });
 
@@ -229,7 +230,7 @@ describe("buildYieldViewModel", () => {
   });
 
   it("derives view-rank labels inside the filtered comparable set", () => {
-    const model = buildYieldViewModel(prepareYieldUniverse(rows, null), { peg: "non-usd" });
+    const model = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", peg: "non-usd" });
 
     expect(model.visibleRows).toHaveLength(1);
     expect(model.visibleRows[0]).toMatchObject({
@@ -261,14 +262,14 @@ describe("buildYieldViewModel", () => {
   });
 
   it("filters by URL-backed source depth lens", () => {
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { depth: "thin" }).visibleRows.map((row) => row.id)).toEqual(["usdc-circle"]);
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { depth: "moderate" }).visibleRows.map((row) => row.id)).toEqual(["usdt-tether"]);
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { depth: "hide-thin" }).visibleRows.map((row) => row.id)).toEqual([
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", depth: "thin" }).visibleRows.map((row) => row.id)).toEqual(["usdc-circle"]);
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", depth: "moderate" }).visibleRows.map((row) => row.id)).toEqual(["usdt-tether"]);
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", depth: "hide-thin" }).visibleRows.map((row) => row.id)).toEqual([
       "eurc-circle",
       "usdt-tether",
     ]);
 
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), {}).options.depth.find((option) => option.value === "hide-thin")).toEqual({
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any" }).options.depth.find((option) => option.value === "hide-thin")).toEqual({
       value: "hide-thin",
       label: "Hide thin venues",
       count: 2,
@@ -276,10 +277,10 @@ describe("buildYieldViewModel", () => {
   });
 
   it("filters rows with changed sources from URL state", () => {
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { sourceChanged: "only" }).visibleRows.map((row) => row.id)).toEqual([
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", sourceChanged: "only" }).visibleRows.map((row) => row.id)).toEqual([
       "usdc-circle",
     ]);
-    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { sourceChanged: "none" }).visibleRows.map((row) => row.id)).toEqual([
+    expect(buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any", sourceChanged: "none" }).visibleRows.map((row) => row.id)).toEqual([
       "eurc-circle",
       "usdt-tether",
     ]);
@@ -328,19 +329,19 @@ describe("buildYieldViewModel", () => {
       }),
     ];
 
-    const clean = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { sourcePosture: "clean" });
+    const clean = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { risk: "any", sourcePosture: "clean" });
     expect(clean.visibleRows.map((row) => row.id)).toEqual(["clean-row"]);
     expect(clean.comparisonLabel).toBe("Clean source posture");
 
-    const watch = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { sourcePosture: "watch" });
+    const watch = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { risk: "any", sourcePosture: "watch" });
     expect(watch.visibleRows.map((row) => row.id)).toEqual(["clean-row", "watch-row"]);
     expect(watch.comparisonLabel).toBe("Clean/watch source posture");
 
-    const watchOnly = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { sourcePosture: "watch-only" });
+    const watchOnly = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { risk: "any", sourcePosture: "watch-only" });
     expect(watchOnly.visibleRows.map((row) => row.id)).toEqual(["watch-row"]);
     expect(watchOnly.comparisonLabel).toBe("Watch source posture");
 
-    const speculative = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { sourcePosture: "speculative" });
+    const speculative = buildYieldViewModel(prepareYieldUniverse(postureRows, null), { risk: "any", sourcePosture: "speculative" });
     expect(speculative.visibleRows.map((row) => row.id)).toEqual(["spec-row"]);
     expect(speculative.options.sourcePosture).toEqual([
       { value: "all", label: "All postures", count: 3 },
@@ -385,15 +386,26 @@ describe("buildYieldViewModel", () => {
   });
 
   it("marks the active preset and counts its matching rows", () => {
+    // Stacking contract: the landing band fills minSafety=50, but preset
+    // matching only checks the preset's own override keys, so
+    // watchlist-warnings stays active on top of the band. The count is
+    // evaluated on the stacked filters — the null-safety EURC row never
+    // clears the band's safety floor, so only two watched rows count.
     const warningsModel = buildYieldViewModel(prepareYieldUniverse(rows, new Set(["usdc-circle", "eurc-circle", "usdt-tether"])), {
       attention: "watchlist",
+      warnings: "all",
     });
     expect(warningsModel.matchingPreset).toBe("watchlist-warnings");
     const watchlist = warningsModel.presets.find((preset) => preset.key === "watchlist-warnings");
     expect(watchlist?.active).toBe(true);
-    expect(watchlist?.count).toBe(3);
+    expect(watchlist?.count).toBe(2);
 
-    const defaultModel = buildYieldViewModel(prepareYieldUniverse(rows, null), {});
+    // A partial override match is inactive: the band fills warnings=hide,
+    // which the preset's overrides do not match.
+    const mismatched = buildYieldViewModel(prepareYieldUniverse(rows, null), { attention: "watchlist" });
+    expect(mismatched.matchingPreset).toBeNull();
+
+    const defaultModel = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any" });
     expect(defaultModel.matchingPreset).toBeNull();
   });
 
@@ -457,7 +469,7 @@ describe("buildYieldViewModel", () => {
   });
 
   it("defaults to all when watchlistIds is not provided", () => {
-    const model = buildYieldViewModel(prepareYieldUniverse(rows, null), {});
+    const model = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any" });
 
     expect(model.filters.watchlist).toBe("all");
     expect(model.visibleRows.map((row) => row.id)).toEqual(["usdc-circle", "eurc-circle", "usdt-tether"]);
@@ -467,21 +479,21 @@ describe("buildYieldViewModel", () => {
   it("counts watchlist matches and filters to only watchlist rows", () => {
     const watchlistIds = new Set(["usdc-circle", "usdt-tether"]);
 
-    const allModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), {});
+    const allModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), { risk: "any" });
     expect(allModel.options.watchlist.find((option) => option.value === "only")?.count).toBe(2);
     expect(allModel.visibleRows).toHaveLength(3);
 
-    const onlyModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), { watchlist: "only" });
+    const onlyModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), { risk: "any", watchlist: "only" });
     expect(onlyModel.visibleRows.map((row) => row.id)).toEqual(["usdc-circle", "usdt-tether"]);
   });
 
   it("filters watched rows that need attention without forcing warnings/source-changed AND semantics", () => {
     const watchlistIds = new Set(["usdc-circle", "eurc-circle", "usdt-tether"]);
 
-    const allModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), {});
+    const allModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), { risk: "any" });
     expect(allModel.options.attention.find((option) => option.value === "watchlist")?.count).toBe(3);
 
-    const attentionModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), { attention: "watchlist" });
+    const attentionModel = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), { risk: "any", attention: "watchlist" });
     expect(attentionModel.visibleRows.map((row) => row.id)).toEqual([
       "usdc-circle",
       "eurc-circle",
@@ -490,6 +502,7 @@ describe("buildYieldViewModel", () => {
     expect(attentionModel.comparisonLabel).toBe("Watched rows needing attention");
 
     const warningAndChangedOnly = buildYieldViewModel(prepareYieldUniverse(rows, watchlistIds), {
+      risk: "any",
       watchlist: "only",
       warnings: "only",
       sourceChanged: "only",
@@ -511,34 +524,26 @@ describe("buildYieldViewModel", () => {
   });
 
   it("matches each risk-budget stop's filter overrides to its matching key", () => {
-    const conservative = buildYieldViewModel(prepareYieldUniverse(rows, null), {
-      minSafety: "80",
-      depth: "hide-thin",
-      sourcePosture: "clean",
-      warnings: "hide",
-    });
+    // Empty URL lands on the opportunistic band, risk=any is the neutral
+    // band, and an explicit key stacked on the landing band matches no stop.
+    const landing = buildYieldViewModel(prepareYieldUniverse(rows, null), {});
+    expect(landing.riskBudget.matching).toBe("opportunistic");
+
+    const any = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "any" });
+    expect(any.riskBudget.matching).toBe("all");
+
+    const conservative = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "conservative" });
     expect(conservative.riskBudget.matching).toBe("conservative");
 
-    const balanced = buildYieldViewModel(prepareYieldUniverse(rows, null), {
-      minSafety: "70",
-      depth: "hide-thin",
-      sourcePosture: "watch",
-      warnings: "hide",
-    });
+    const balanced = buildYieldViewModel(prepareYieldUniverse(rows, null), { risk: "balanced" });
     expect(balanced.riskBudget.matching).toBe("balanced");
 
-    const opportunistic = buildYieldViewModel(prepareYieldUniverse(rows, null), {
-      minSafety: "50",
-      warnings: "hide",
-    });
-    expect(opportunistic.riskBudget.matching).toBe("opportunistic");
+    const stacked = buildYieldViewModel(prepareYieldUniverse(rows, null), { minSafety: "80" });
+    expect(stacked.riskBudget.matching).toBeNull();
 
-    const all = buildYieldViewModel(prepareYieldUniverse(rows, null), {});
-    expect(all.riskBudget.matching).toBe("all");
-
-    const stops = all.riskBudget.stops.map((stop) => stop.key);
+    const stops = any.riskBudget.stops.map((stop) => stop.key);
     expect(stops).toEqual(["conservative", "balanced", "opportunistic", "all"]);
-    expect(all.riskBudget.stops.every((stop) => stop.count >= 0)).toBe(true);
+    expect(any.riskBudget.stops.every((stop) => stop.count >= 0)).toBe(true);
   });
 
   it("returns null matchingRiskBudget when filters don't match any stop", () => {
@@ -547,12 +552,49 @@ describe("buildYieldViewModel", () => {
     expect(model.riskBudget.stops.every((stop) => stop.active === false)).toBe(true);
   });
 
+  it("applies the opportunistic landing band only when the URL omits risk", () => {
+    const bandRows = [
+      makeYieldRanking({ id: "low-safety", symbol: "LOW", safetyScore: 40, warningSignals: [] }),
+      makeYieldRanking({ id: "warned", symbol: "WRN", safetyScore: 90, warningSignals: ["data-stale"] }),
+    ];
+
+    const landing = buildYieldViewModel(prepareYieldUniverse(bandRows, null), {});
+    expect(landing.visibleRows.map((row) => row.id)).toEqual([]);
+
+    const neutral = buildYieldViewModel(prepareYieldUniverse(bandRows, null), { risk: "any" });
+    expect(neutral.visibleRows.map((row) => row.id).sort()).toEqual(["low-safety", "warned"]);
+  });
+
+  it("stacks explicit risk-budget params on top of the landing band", () => {
+    const stacked = buildYieldViewModel(prepareYieldUniverse(rows, null), { minSafety: "80" });
+
+    // The band fills only the keys the URL leaves unset (warnings=hide), so
+    // warning and null-safety rows stay hidden alongside the explicit floor,
+    // and the implicit landing band is not echoed back into the URL state.
+    expect(stacked.visibleRows.map((row) => row.id)).toEqual(["usdc-circle"]);
+    expect(stacked.normalizedParams.risk).toBeNull();
+  });
+
+  it("offers lifting the whole landing band when single-axis relaxations recover nothing", () => {
+    const blocked = [
+      makeYieldRanking({ id: "risky-row", symbol: "RISKY", safetyScore: 40, warningSignals: ["data-stale"] }),
+    ];
+    const model = buildYieldViewModel(prepareYieldUniverse(blocked, null), { q: "risky" });
+
+    expect(model.visibleRows).toEqual([]);
+    // Clearing q, the safety floor, or the warnings filter alone still leaves
+    // the row blocked by the other band keys; only risk=any lifts both.
+    expect(model.emptyState.suggestions.map((s) => s.filterKey)).toEqual(["risk"]);
+    expect(model.emptyState.suggestions[0]).toMatchObject({ targetValue: "any", gain: 1 });
+  });
+
   it("computes empty-state suggestions ranked by row recovery", () => {
     // Designed so dropping any of these three filters recovers a non-empty subset:
     //   peg=USD ∧ warnings=only ∧ benchmark=EUR
     // Drop peg → EURC matches (warnings+EUR). Drop benchmark → USDT matches.
     // Drop warnings → still empty (USDC/USDT are USD-not-EUR). Top 3 by gain.
     const model = buildYieldViewModel(prepareYieldUniverse(rows, null), {
+      risk: "any",
       peg: "USD",
       warnings: "only",
       benchmark: "EUR",

--- a/src/lib/methodology-context.ts
+++ b/src/lib/methodology-context.ts
@@ -351,9 +351,9 @@ export const METHODOLOGY_CONTEXT: Record<MethodologyContextKey, MethodologyConte
   pys: {
     title: "PYS",
     summary:
-      "Benchmark-aware risk-adjusted yield score that starts from APY, adds a weighted slice of benchmark spread, then discounts by source risk, stablecoin safety, and yield consistency.",
+      "Asks one question: is this APY paying enough for the risk you take? Yield per unit of risk, 0-100. Starts from APY, adds a weighted slice of benchmark spread, then discounts by source risk, stablecoin safety, and yield consistency.",
     detail:
-      "High APY on weak safety or thin source evidence still needs an exceptional edge because source-risk and safety penalties are deliberately steep, while stronger local-currency benchmark outperformance now gets explicit credit.",
+      "Not a recommendation or a safety verdict: a D-grade coin can top PYS because it pays a lot for a lot of risk. Read it next to the Safety grade and the row's zone. Source-risk and safety penalties are deliberately steep, and local-currency benchmark outperformance gets explicit credit.",
     methodologyPath: "/methodology/#yield-intelligence-methodology",
     versionLabel: YIELD_METHODOLOGY_VERSION_LABEL,
     changelogPath: YIELD_METHODOLOGY_CHANGELOG_PATH,

--- a/src/lib/yield-scatter.ts
+++ b/src/lib/yield-scatter.ts
@@ -1,7 +1,24 @@
+import type { YieldZoneKey } from "@shared/lib/classification";
 import { clamp } from "@shared/lib/math";
 import { percentileLinear } from "@shared/lib/stats";
 
 export const SAFETY_SCORE_THRESHOLD = 60;
+
+/**
+ * Joint safety × yield zone for one row, using the same split as the scatter
+ * quadrants. Null when the row is unscored or has no benchmark to compare to.
+ */
+export function resolveYieldZone(
+  safetyScore: number | null,
+  apy30d: number,
+  benchmarkRate: number | null | undefined,
+): YieldZoneKey | null {
+  if (safetyScore === null || benchmarkRate == null || !Number.isFinite(benchmarkRate)) return null;
+  const safe = safetyScore >= SAFETY_SCORE_THRESHOLD;
+  const paid = apy30d > benchmarkRate;
+  if (safe) return paid ? "sweet-spot" : "play-it-safe";
+  return paid ? "danger-zone" : "why-bother";
+}
 
 const SAFETY_WINDOW_STEP = 5;
 const SAFETY_WINDOW_BUFFER = 5;

--- a/src/lib/yield-view-config.ts
+++ b/src/lib/yield-view-config.ts
@@ -32,6 +32,8 @@ export type YieldWatchlistFilter = "all" | "only";
 export type YieldAttentionFilter = "all" | "watchlist";
 
 export interface YieldViewModelUrlParams {
+  /** Risk-tolerance band; absent = `YIELD_LANDING_RISK_BUDGET`, `any` = no band. */
+  risk?: string | null;
   peg?: string | null;
   yieldType?: string | null;
   q?: string | null;
@@ -142,6 +144,15 @@ export const DEFAULT_FILTERS: YieldViewModelFilters = {
   attention: "all",
 };
 
+/**
+ * Risk band applied when the URL carries no `risk` param and no explicit
+ * risk-budget filter. The neutral "all" band must be requested explicitly via
+ * `risk=any` so D-grade rows never lead the page by default.
+ */
+export const YIELD_LANDING_RISK_BUDGET: YieldRiskBudgetKey = "opportunistic";
+/** URL value for the neutral band; not "all" because `setParam` treats "all" as clear. */
+export const YIELD_RISK_ANY_PARAM = "any";
+
 export interface YieldPresetSpec {
   key: YieldPresetKey;
   label: string;
@@ -240,7 +251,8 @@ export const YIELD_PRESET_SPECS: readonly YieldPresetSpec[] = [
     key: "watchlist-warnings",
     label: "Watching needs attention",
     description: "Starred rows with warnings or source changes",
-    overrides: { attention: "watchlist" },
+    // WHY: the landing risk band hides warning rows, which this view exists to surface.
+    overrides: { attention: "watchlist", warnings: "all" },
   },
 ];
 

--- a/src/lib/yield-view-model-presentation.ts
+++ b/src/lib/yield-view-model-presentation.ts
@@ -19,6 +19,7 @@ import type {
 import {
   DEFAULT_FILTERS,
   YIELD_PRESET_SPECS,
+  YIELD_RISK_ANY_PARAM,
   YIELD_RISK_BUDGET_SPECS,
   type YieldPresetSpec,
   type YieldRiskBudgetSpec,
@@ -97,6 +98,17 @@ function buildEmptyStateSuggestions(
       });
     }
   }
+  // Band keys often only recover rows together (a low-grade row with a
+  // warning is blocked by both the safety floor and the warnings filter), so
+  // offer lifting the whole band as one move.
+  if (RISK_BUDGET_FILTER_KEYS.some((key) => filters[key] !== DEFAULT_FILTERS[key])) {
+    const unbanded = { ...filters };
+    for (const key of RISK_BUDGET_FILTER_KEYS) (unbanded as Record<keyof YieldViewModelFilters, unknown>)[key] = DEFAULT_FILTERS[key];
+    const gain = countRowsMatchingFilters(facets, unbanded);
+    if (gain > 0) {
+      scored.push({ filterKey: "risk", targetValue: YIELD_RISK_ANY_PARAM, gain, label: "Show all risk levels" });
+    }
+  }
   scored.sort((left, right) => right.gain - left.gain);
   return scored.slice(0, EMPTY_STATE_SUGGESTION_LIMIT);
 }
@@ -125,14 +137,16 @@ function applyOverrides(overrides: Partial<YieldViewModelFilters>): YieldViewMod
   return { ...DEFAULT_FILTERS, ...overrides };
 }
 
-function presetFilters(spec: YieldPresetSpec): YieldViewModelFilters {
-  return applyOverrides(spec.overrides);
+// Presets merge onto the current filters when clicked (see
+// `handleApplyPreset`), so counts and the active state must be evaluated on the
+// same stacked base — otherwise the landing risk band makes every count lie.
+function presetFilters(filters: YieldViewModelFilters, spec: YieldPresetSpec): YieldViewModelFilters {
+  return { ...filters, ...spec.overrides };
 }
 
 function filtersMatchPreset(filters: YieldViewModelFilters, spec: YieldPresetSpec): boolean {
-  const target = presetFilters(spec);
-  return (Object.keys(DEFAULT_FILTERS) as Array<keyof YieldViewModelFilters>).every(
-    (key) => filters[key] === target[key],
+  return (Object.keys(spec.overrides) as Array<keyof YieldViewModelFilters>).every(
+    (key) => filters[key] === spec.overrides[key],
   );
 }
 
@@ -148,7 +162,7 @@ export function buildYieldPresets(
       key: spec.key,
       label: spec.label,
       description: spec.description,
-      count: countRowsMatchingFilters(facets, presetFilters(spec)),
+      count: countRowsMatchingFilters(facets, presetFilters(filters, spec)),
       active,
       overrides: spec.overrides,
     } satisfies YieldPresetState;

--- a/src/lib/yield-view-model-types.ts
+++ b/src/lib/yield-view-model-types.ts
@@ -70,7 +70,8 @@ export interface YieldRiskBudgetState {
 }
 
 export interface YieldEmptyStateSuggestion {
-  filterKey: keyof YieldViewModelFilters;
+  /** A filter axis, or `risk` to lift the whole risk band at once. */
+  filterKey: keyof YieldViewModelFilters | "risk";
   targetValue: string | null;
   gain: number;
   label: string;

--- a/src/lib/yield-view-model.ts
+++ b/src/lib/yield-view-model.ts
@@ -28,9 +28,10 @@ import type { YieldWorkbenchRanking } from "@/lib/yield-workbench-row";
 
 export type { BuildYieldViewModelOptions, YieldActiveFilterSummary, YieldCohortPercentile, YieldPresetKey, YieldRiskBudgetKey, YieldRiskBudgetStop, YieldViewModel, YieldViewModelRow, YieldViewModelUrlParams } from "@/lib/yield-view-model-types";
 
-export { YIELD_PRESET_SPECS, YIELD_RISK_BUDGET_MIN_SAFETY, YIELD_RISK_BUDGET_SPECS } from "@/lib/yield-view-config";
+export { YIELD_LANDING_RISK_BUDGET, YIELD_PRESET_SPECS, YIELD_RISK_BUDGET_MIN_SAFETY, YIELD_RISK_BUDGET_SPECS } from "@/lib/yield-view-config";
 export { YIELD_FILTER_AXIS_REGISTRY } from "@/lib/yield-view-model-filter-axes";
 export { RISK_BUDGET_FILTER_KEYS } from "@/lib/yield-view-model-presentation";
+export { riskBudgetUrlValue } from "@/lib/yield-view-url";
 
 /** Per-universe preparation shared by every view over one rankings set: row facets, filter options, and the cohort index over the unfiltered rows. */
 export interface PreparedYieldUniverse {

--- a/src/lib/yield-view-url.ts
+++ b/src/lib/yield-view-url.ts
@@ -1,4 +1,10 @@
-import { DEFAULT_FILTERS } from "@/lib/yield-view-config";
+import {
+  DEFAULT_FILTERS,
+  YIELD_LANDING_RISK_BUDGET,
+  YIELD_RISK_ANY_PARAM,
+  YIELD_RISK_BUDGET_SPECS,
+  type YieldRiskBudgetKey,
+} from "@/lib/yield-view-config";
 import type {
   YieldBenchmarkFilter,
   YieldDepthFilter,
@@ -50,7 +56,39 @@ function normalizeOption<T extends string>(
   return value != null && validValues.has(value as T) ? value as T : fallback;
 }
 
-export function normalizeFilters(params: YieldViewModelUrlParams, options: YieldViewModelOptions): {
+function parseRiskBudgetParam(value: string | null | undefined): YieldRiskBudgetKey {
+  if (value == null || value.trim() === "") return YIELD_LANDING_RISK_BUDGET;
+  if (value === YIELD_RISK_ANY_PARAM || value === "all") return "all";
+  return YIELD_RISK_BUDGET_SPECS.some((spec) => spec.key === value)
+    ? (value as YieldRiskBudgetKey)
+    : YIELD_LANDING_RISK_BUDGET;
+}
+
+export function riskBudgetUrlValue(key: YieldRiskBudgetKey): string {
+  return key === "all" ? YIELD_RISK_ANY_PARAM : key;
+}
+
+/**
+ * Applies the URL risk band to every risk-budget key the URL leaves unset, so
+ * `/yield/` lands on the opportunistic band while explicit filter params still
+ * win (stackable semantics). `risk=any` requests the neutral defaults.
+ */
+function expandRiskBudget(params: YieldViewModelUrlParams): {
+  risk: YieldRiskBudgetKey;
+  params: YieldViewModelUrlParams;
+} {
+  const risk = parseRiskBudgetParam(params.risk);
+  const spec = YIELD_RISK_BUDGET_SPECS.find((entry) => entry.key === risk);
+  const expanded: YieldViewModelUrlParams = { ...params };
+  for (const [key, value] of Object.entries(spec?.overrides ?? {})) {
+    const paramKey = key as keyof YieldViewModelUrlParams;
+    const raw = expanded[paramKey];
+    if ((raw == null || raw.trim() === "") && value != null) expanded[paramKey] = String(value);
+  }
+  return { risk, params: expanded };
+}
+
+export function normalizeFilters(rawParams: YieldViewModelUrlParams, options: YieldViewModelOptions): {
   filters: YieldViewModelFilters;
   normalizedParams: Record<keyof YieldViewModelUrlParams, string | null>;
   invalidParamKeys: Array<keyof YieldViewModelUrlParams>;
@@ -70,6 +108,7 @@ export function normalizeFilters(params: YieldViewModelUrlParams, options: Yield
   const validTrending = new Set<YieldTrendingFilter>(["all", "rising"]);
   const validWatchlist = new Set<YieldWatchlistFilter>(["all", "only"]);
   const validAttention = new Set<YieldAttentionFilter>(["all", "watchlist"]);
+  const { risk, params } = expandRiskBudget(rawParams);
 
   const filters: YieldViewModelFilters = {
     peg: normalizeOption(params.peg, validPegValues, DEFAULT_FILTERS.peg),
@@ -90,6 +129,7 @@ export function normalizeFilters(params: YieldViewModelUrlParams, options: Yield
   };
 
   const normalizedParams: Record<keyof YieldViewModelUrlParams, string | null> = {
+    risk: risk === YIELD_LANDING_RISK_BUDGET ? null : riskBudgetUrlValue(risk),
     peg: filters.peg === DEFAULT_FILTERS.peg ? null : filters.peg,
     yieldType: filters.yieldType === DEFAULT_FILTERS.yieldType ? null : filters.yieldType,
     q: filters.q === DEFAULT_FILTERS.q ? null : filters.q,
@@ -109,7 +149,7 @@ export function normalizeFilters(params: YieldViewModelUrlParams, options: Yield
 
   const invalidParamKeys = (Object.keys(normalizedParams) as Array<keyof YieldViewModelUrlParams>)
     .filter((key) => {
-      const raw = params[key];
+      const raw = rawParams[key];
       const normalized = normalizedParams[key];
       return raw != null && raw.trim() !== "" && raw !== normalized;
     });


### PR DESCRIPTION
## Why
Users read the PYS-sorted leaderboard as a recommendation list; a D-grade coin with a huge APY (wTRY) looked endorsed at rank 4. PYS answers "am I paid enough for the risk?", not "is this safe?", and the page never said so.

## What
- Per-row zone chip (Sweet Spot / Danger Zone / Play It Safe / Why Bother?) from the same safety-60 x benchmark split as the scatter quadrants; labels/styles in `shared/lib/classification`, scatter reads them from there; hero context leads with the zone.
- Every PYS surface (header tooltip, methodology hint, FAQ, meta description, hero label) reworded around the pay-for-risk question; states it is not a recommendation.
- `/yield` lands on the Opportunistic band via a new `risk` URL param (absent = opportunistic, `any` = no band, explicit filter keys win). Presets stack on current filters; compare universe stays unbanded; empty state offers "Show all risk levels".
- Page lead spans the container (`leadFullWidth`).
- Docs: PYS framing, zone chip, landing band, known non-USD benchmark limitation.

## Verification
- `tsc --noEmit` clean; `vitest run src shared`: 1763 files / 19499 tests pass.
- `check:doc-source-paths`, `check:verified-doc-links`, `check:generated-artifacts --only=llms-txt,og-editorial` OK.
- Browser (next dev): landing shows 80/156 rows on Opportunistic; `risk=any` shows 156; wiTRY row renders `Danger Zone`; empty-state "Show all risk levels" recovers a searched low-grade row; clearing the 50+ safety pill writes `risk=any&warnings=hide`.

No methodology version change (v8.42).