### PR TITLE
fix(yield): never attribute movement across a methodology version boundary

### DIFF
--- a/worker/src/api/__tests__/yield-rankings.test.ts
+++ b/worker/src/api/__tests__/yield-rankings.test.ts
@@ -1348,7 +1348,7 @@ describe("handleYieldRankings", () => {
     expect(stable?.rankChangeAttribution?.driverContributions?.stablecoinSafety).toBeNull();
   });
 
-  it("attributes a methodology bump when the payload was published under another version", async () => {
+  it("serves no movement for a payload published under another methodology version", async () => {
     const updatedAt = Math.floor(Date.now() / 1000) - 30;
     // The payload must have been published under an *older* version, so the
     // fixture version is derived from the current constant: the mismatch stays
@@ -1395,11 +1395,12 @@ describe("handleYieldRankings", () => {
     const mover = body.rankings.find((entry) => entry.id === "mover-coin");
     const stable = body.rankings.find((entry) => entry.id === "stable-coin");
 
-    // A version bump explains every delta, so it outranks the row-level safety
-    // signal on both the mover and the row it displaced.
+    // Scores from two methodologies are not comparable, so the read path serves
+    // no movement and no driver rather than fabricating a delta from the version
+    // bump alone (B7 rollout: this mislabelled tie-group reorders as movements).
     expect(publishedVersion).not.toBe(YIELD_METHODOLOGY_VERSION);
-    expect(mover?.rankChangeAttribution?.primaryDriver).toBe("methodology");
-    expect(stable?.rankChangeAttribution?.primaryDriver).toBe("methodology");
+    expect(mover?.rankChangeAttribution ?? null).toBeNull();
+    expect(stable?.rankChangeAttribution ?? null).toBeNull();
   });
 
   it("keeps a non-safety pysNullReason through the degraded safety path", async () => {

--- a/worker/src/lib/yield-rank-attribution.ts
+++ b/worker/src/lib/yield-rank-attribution.ts
@@ -138,6 +138,12 @@ export function buildYieldRankChangeAttribution(
     return params.originalRow.rankChangeAttribution ?? null;
   }
 
+  // A payload published under a different methodology version cannot be scored by
+  // this one: its `pharosYieldScore` came from other rules, so any delta compares
+  // two methodologies rather than movement in this row's evidence. Serve no
+  // movement instead of a fabricated one (B7 rollout).
+  if (params.methodologyChanged) return null;
+
   const previousPys = finiteNumber(params.originalRow.pharosYieldScore);
   const livePys = finiteNumber(params.hydratedRow.pharosYieldScore);
   const pysDelta = previousPys != null && livePys != null ? roundDelta(livePys - previousPys) : null;


### PR DESCRIPTION
Post-deploy acceptance on `b14c768b1` surfaced a real defect: the first v8.43 publication attributed a `methodology` driver with fabricated PYS deltas (bold-liquity -42 while its score went 70 to 69; 126 rows affected) because the read path compared the old payload's scores with scores recomputed under the new rules.

## Fix
`buildYieldRankChangeAttribution` returns null when the payload was published under a different methodology version — no delta, no rank movement, no driver. Nothing else changes; publish-time attribution between same-version payloads keeps working.

## Verification
- Worker tsc clean; lint:changed clean; composite static gate exit 0.
- `yield-rankings` (test re-pointed to the corrected semantics), `yield-publication`, and the DEWS suites: 82 passed.

## Post-deploy observation to confirm
The next `hourlyYieldSync` publication should serve `rankChangeAttribution: null` for every row until the 8.43-and-later payload becomes its own baseline (one cycle), and no `bold-liquity`-style -42 delta.