### PR TITLE
fix(yield): bound the history retention drain so it cannot blow the D1 CPU limit

### DIFF
--- a/worker/src/cron/__tests__/yield-history-snapshots.test.ts
+++ b/worker/src/cron/__tests__/yield-history-snapshots.test.ts
@@ -11,7 +11,7 @@ import {
   MAX_PREVIOUS_TVL_HISTORY_ROWS,
   purgeYieldHistoryOwnershipHandoffs,
 } from "../yield-sync/history";
-import { pruneYieldTables } from "../yield-sync/publication";
+import { drainRowsBeforeCutoff, pruneYieldTables } from "../yield-sync/publication";
 
 function createDb(): { sqlite: DatabaseSync; db: D1Database } {
   return createLatestSchemaSqlite();
@@ -343,5 +343,59 @@ describe("pruneYieldTables retention", () => {
     expect(sqlite.prepare("SELECT snapshot_date FROM yield_history_daily").all()).toEqual([
       { snapshot_date: nowSec - 100 * DAY_SECONDS },
     ]);
+  });
+
+  it("resumes a large retention backlog across bounded statements instead of one fatal delete", async () => {
+    // Regression: v8.43 moved the raw-history cutoff from 365d to 30d, putting
+    // the entire 30d-365d backlog in scope at once. One unbounded DELETE over
+    // millions of rows exceeded the D1 per-query CPU limit, failing the whole
+    // publication run with `D1_ERROR: D1 DB exceeded its CPU time limit` — and
+    // it failed the same way every hour. The drain must be bounded and resumable.
+    const fixture = createDb();
+    sqlite = fixture.sqlite;
+    const nowSec = 1_800_000_000;
+    const cutoffSec = nowSec - 30 * DAY_SECONDS;
+    for (let index = 0; index < 12_000; index += 1) {
+      insertHistory(sqlite, {
+        stablecoinId: `coin-${index % 20}`,
+        sourceKey: "source-a",
+        recordedAt: nowSec - 40 * DAY_SECONDS - index,
+      });
+    }
+    const countRows = (): number => {
+      const row = sqlite?.prepare("SELECT COUNT(*) AS n FROM yield_history").get();
+      if (!row || typeof row !== "object" || !("n" in row) || typeof row.n !== "number") {
+        throw new Error("unexpected sqlite count shape");
+      }
+      return row.n;
+    };
+    expect(countRows()).toBe(12_000);
+
+    const drain = () =>
+      drainRowsBeforeCutoff({
+        db: fixture.db,
+        table: "yield_history",
+        statementTag: "history-retention-delete",
+        timeColumn: "recorded_at",
+        cutoffSec,
+        frozenIdsList: [],
+        frozenClause: "",
+        maxRows: 5_000,
+      });
+
+    // Three bounded passes, each capped, and the third finds only the remainder.
+    const first = await drain();
+    expect(first.deleted).toBe(5_000);
+    expect(first.budgetExhausted).toBe(true);
+    expect(countRows()).toBe(7_000);
+
+    const second = await drain();
+    expect(second.deleted).toBe(5_000);
+    expect(countRows()).toBe(2_000);
+
+    const third = await drain();
+    expect(third.deleted).toBe(2_000);
+    expect(third.budgetExhausted).toBe(false);
+    expect(countRows()).toBe(0);
   });
 });

--- a/worker/src/cron/yield-sync/publication.ts
+++ b/worker/src/cron/yield-sync/publication.ts
@@ -4,6 +4,7 @@ import { ACTIVE_STABLECOINS, FROZEN_IDS } from "@shared/lib/stablecoins/registry
 import { YIELD_HISTORY_MAX_DAYS, YIELD_HISTORY_RAW_DAYS } from "@shared/lib/yield-history-policy";
 import { deleteOrphanYieldRows, deleteStaleYieldRows, purgeYieldHistoryOwnershipHandoffs } from "./history";
 import { runWithOverloadRetry } from "../../lib/d1-overload-retry";
+import { logWorkerEvent } from "../../lib/structured-log";
 
 export {
   derivePreviousYieldRankingsCount,
@@ -143,6 +144,85 @@ export async function pruneYieldTables(
   await runWithOverloadRetry(() => pruneYieldTablesOnce(db, startSec, options), 3, options?.signal);
 }
 
+/**
+ * Rows removed per statement. Small enough that a single statement stays far
+ * inside the D1 per-query CPU budget even on a wide index scan.
+ */
+const RETENTION_DELETE_CHUNK_ROWS = 5_000;
+/**
+ * Ceiling on rows removed per run. A retention-boundary change can put millions
+ * of rows in scope at once; draining them in one invocation would exceed the D1
+ * CPU limit and fail the whole publication run, so each run removes a bounded
+ * slice and the next run continues. Exceeding this budget is expected after a
+ * boundary change and is reported by the log line below.
+ */
+const RETENTION_DELETE_MAX_ROWS_PER_RUN = 250_000;
+
+/**
+ * Delete every row of `table` older than `cutoffSec` (by `timeColumn`), in
+ * bounded statements, so a large backlog drains across runs instead of failing
+ * one. `rowid` is used for the chunk selection because every retention table is
+ * a plain rowid table; both tables index their time column, so each bounded
+ * statement is an index range scan rather than a full scan.
+ *
+ * Exported with an explicit `maxRows` budget: the production default is
+ * {@link RETENTION_DELETE_MAX_ROWS_PER_RUN}, and a smaller budget exercises the
+ * resumable path in tests.
+ */
+export async function drainRowsBeforeCutoff(params: {
+  db: D1Database;
+  table: "yield_history" | "yield_history_daily";
+  statementTag: string;
+  timeColumn: "recorded_at" | "snapshot_date";
+  cutoffSec: number;
+  frozenIdsList: number[] | string[];
+  frozenClause: string;
+  maxRows?: number;
+}): Promise<{ deleted: number; budgetExhausted: boolean }> {
+  const { db, table, statementTag, timeColumn, cutoffSec, frozenIdsList, frozenClause } = params;
+  const perRunBudget = Math.max(
+    RETENTION_DELETE_CHUNK_ROWS,
+    params.maxRows ?? RETENTION_DELETE_MAX_ROWS_PER_RUN,
+  );
+  let remainingBudget = perRunBudget;
+  let deleted = 0;
+
+  while (remainingBudget > 0) {
+    const chunkRows = Math.min(RETENTION_DELETE_CHUNK_ROWS, remainingBudget);
+    const result = await db
+      .prepare(
+        `/* pharos:yield-sync:${statementTag} */
+         DELETE FROM ${table}
+          WHERE rowid IN (
+            SELECT rowid FROM ${table}
+             WHERE ${timeColumn} < ? ${frozenClause}
+             ORDER BY ${timeColumn} ASC
+             LIMIT ?
+          )`,
+      )
+      .bind(cutoffSec, ...frozenIdsList, chunkRows)
+      .run();
+    const changed = Number(result.meta?.changes ?? 0);
+    if (!Number.isFinite(changed) || changed <= 0) break;
+    deleted += changed;
+    remainingBudget -= changed;
+    // A short statement means the backlog is exhausted.
+    if (changed < chunkRows) break;
+  }
+
+  const budgetExhausted = remainingBudget <= 0 && deleted >= perRunBudget;
+  if (budgetExhausted) {
+    logWorkerEvent({
+      scope: "handler",
+      level: "info",
+      event: "yield-history-retention-drain-continues",
+      message: `Retention drain for ${table} hit its per-run row budget; the remainder continues on the next publication run.`,
+      metadata: { table, deleted, budget: perRunBudget },
+    });
+  }
+  return { deleted, budgetExhausted };
+}
+
 async function pruneYieldTablesOnce(
   db: D1Database,
   startSec: number,
@@ -176,6 +256,14 @@ async function pruneYieldTablesOnce(
   // rows only need the 30-day full-fidelity policy; the daily tier keeps the
   // 365-day cutoff. Materialization above ran first, so the trailing raw day
   // was already closed into the daily tier before it leaves the raw window.
+  //
+  // Both deletes are drained in bounded statements. A retention boundary change
+  // (v8.43 moved the raw cutoff from 365d to 30d) leaves the whole backlog
+  // eligible at once, and one unbounded DELETE over millions of rows exceeds the
+  // D1 per-query CPU limit — which failed the entire run with
+  // `D1_ERROR: D1 DB exceeded its CPU time limit`, every hour, forever. A chunk
+  // that cannot commit leaves the table unchanged, so the drain must be bounded
+  // and resumable rather than atomic.
   const rawPruneCutoff = startSec - YIELD_HISTORY_RAW_DAYS * DAY_SECONDS;
   const pruneCutoff = startSec - YIELD_HISTORY_MAX_DAYS * DAY_SECONDS;
   const frozenIdsList = [...FROZEN_IDS];
@@ -183,15 +271,24 @@ async function pruneYieldTablesOnce(
     frozenIdsList.length > 0
       ? `AND stablecoin_id NOT IN (${frozenIdsList.map(() => "?").join(",")})`
       : "";
-  await db
-    .prepare(`/* pharos:yield-sync:history-retention-delete */ DELETE FROM yield_history WHERE recorded_at < ? ${frozenClause}`)
-    .bind(rawPruneCutoff, ...frozenIdsList)
-    .run();
-
-  await db
-    .prepare(`/* pharos:yield-sync:daily-history-retention-delete */ DELETE FROM yield_history_daily WHERE snapshot_date < ? ${frozenClause}`)
-    .bind(pruneCutoff, ...frozenIdsList)
-    .run();
+  await drainRowsBeforeCutoff({
+    db,
+    table: "yield_history",
+    statementTag: "history-retention-delete",
+    timeColumn: "recorded_at",
+    cutoffSec: rawPruneCutoff,
+    frozenIdsList,
+    frozenClause,
+  });
+  await drainRowsBeforeCutoff({
+    db,
+    table: "yield_history_daily",
+    statementTag: "daily-history-retention-delete",
+    timeColumn: "snapshot_date",
+    cutoffSec: pruneCutoff,
+    frozenIdsList,
+    frozenClause,
+  });
 
   if (allowDestructiveCleanup) {
     await cleanupFalseLinkedVariantSourceSwitches(db);


### PR DESCRIPTION
## Live incident

The two runs after the v8.43 release failed `sync-yield-data` with `D1_ERROR: D1 DB exceeded its CPU time limit and was reset.` (07:55 error 153s, 06:55 error 147s; the six prior runs were ok at 172-178s). The job declares `statusImpact: critical`, so this is why platform status reads `stale` with `cron_error_runs` critical.

## Cause

C15 moved the raw-history prune cutoff from 365d to 30d. The prune was a single unbounded `DELETE FROM yield_history WHERE recorded_at < ?`, so the entire 30d-365d backlog became eligible in one statement. That exceeds D1's per-query CPU budget; the statement cannot commit, so the backlog never shrinks and every subsequent hourly run fails the same way.

## Fix

`drainRowsBeforeCutoff` replaces both retention deletes: 5k-row bounded statements (both tables index their time column, so each is an index range scan), 250k-row per-run cap, resumable across runs, with a `yield-history-retention-drain-continues` log line when the cap is hit. The daily tier is unchanged in scope (still 365d) but shares the bounded drain.

A test pins the cap and the resume behaviour: 5k / 5k / 2k over a 12k-row backlog, asserting `budgetExhausted` and that each pass is bounded.

## Acceptance after deploy

Next `hourlyYieldSync`: `sync-yield-data` returns to `ok` (~175s), the drain log line appears while the backlog clears, and platform status returns from `stale` to a healthy availability. Backlog drains over roughly 10 hourly runs at the 250k cap.