### PR TITLE
fix(yield): stop counting issuer-native rails against venue-tier coverage

### DIFF
--- a/worker/src/lib/status/__tests__/yield-health.test.ts
+++ b/worker/src/lib/status/__tests__/yield-health.test.ts
@@ -791,12 +791,14 @@ describe("loadYieldHealthSummary", () => {
     );
 
     expect(summary.sourceRiskCoverage).toMatchObject({ totalRows: 270, bestRows: 157, altRows: 113 });
-    // 64 derivation-method rows have no venue, so they leave the depth denominator.
+    // 64 derivation-method rows have no venue at all, and a further 34 sit on the
+    // issuer's own rail (`native-wrapper`/`issuer-savings`), so both leave the
+    // depth denominator.
     expect(summary.sourceRiskCoverage.fields.sourceDepthRatio).toMatchObject({
-      eligibleCount: 206,
-      populatedCount: 199,
-      ineligibleCount: 64,
-      coverageRatio: 0.966,
+      eligibleCount: 172,
+      populatedCount: 172,
+      ineligibleCount: 98,
+      coverageRatio: 1,
     });
     // 98 rows publish one undivided rate, so they leave the reward denominator.
     expect(summary.sourceRiskCoverage.fields.rewardShare).toMatchObject({
@@ -805,11 +807,57 @@ describe("loadYieldHealthSummary", () => {
       coverageRatio: 1,
     });
     expect(summary.sourceRiskCoverage.fields.venueRiskTier).toMatchObject({
-      eligibleCount: 206,
-      bestEligibleCount: 93,
-      altEligibleCount: 113,
+      eligibleCount: 172,
       coverageRatio: 0,
     });
+  });
+
+  it("excludes issuer-native rails from the venue-tier denominator", async () => {
+    // Live shape: 81 of 266 published rows sit on the issuer's own rail
+    // (`native-wrapper` / `issuer-savings`) — Sky sUSDS, Ethena sUSDe,
+    // Circle/Hashnote USYC, BlackRock BUIDL, Liquity Stability Pools and the
+    // rest. None can carry an independent venue tier, so counting them pinned
+    // the tile at 0.718 and made healthy unreachable. The third-party venue
+    // stays in the denominator.
+    const summary = await loadYieldHealthSummary(
+      makeDb([
+        yieldCacheRow("yield-rankings", NOW - 300, {
+          updatedAt: NOW - 300,
+          rankings: [
+            {
+              id: "issuer-rail",
+              dataSource: "onchain",
+              apyBase: 4,
+              apyReward: null,
+              sourceRisk: { sourceRiskPenalty: 1, sourceAgeSeconds: 60, observationCount30d: 4, deploymentPlace: "native-wrapper" },
+            },
+            {
+              id: "third-party-venue",
+              dataSource: "defillama",
+              apyBase: 4,
+              apyReward: null,
+              sourceRisk: {
+                sourceRiskPenalty: 1,
+                sourceAgeSeconds: 60,
+                observationCount30d: 4,
+                deploymentPlace: "lending-market",
+                venueRiskTier: "low",
+              },
+            },
+          ],
+          provenance: healthyYieldProvenance(NOW, 2),
+        }),
+        ...supplementalFamilyRows(NOW - 3600),
+        yieldCacheRow("yield-coverage-audit", NOW - 86400, emptyYieldAudit()),
+      ]),
+      NOW,
+      { "sync-yield-data": cron() },
+    );
+
+    const tier = summary.sourceRiskCoverage.fields.venueRiskTier;
+    expect(tier.eligibleCount).toBe(1);
+    expect(tier.populatedCount).toBe(1);
+    expect(tier.coverageRatio).toBe(1);
   });
 
   it("returns a null coverage ratio when no row can carry the field", async () => {

--- a/worker/src/lib/status/yield-health.ts
+++ b/worker/src/lib/status/yield-health.ts
@@ -70,6 +70,26 @@ const ASSET_AS_VENUE_DATA_SOURCES: Record<string, boolean> = {
   "price-derived": true,
   "rate-derived": true,
 };
+// Deployment places that are the issuer's own rail rather than a third-party
+// venue: a staked/savings wrapper the issuer operates (`native-wrapper`) or the
+// issuer's own savings module (`issuer-savings`). The same A7 principle applies
+// as for the derivation methods above — the coin IS the venue, so there is no
+// independent venue tier to review, and the coin's Safety Score already prices
+// that risk. Scoring one here would double-count it.
+//
+// Evidence (yield reliability review, 2026-09-12): ~90 fetched sources across 30
+// published slugs still missing a tier — Sky sUSDS/SSR, Circle/Hashnote USYC,
+// Ethena USDe/sUSDe, Ondo USDY/OUSG, BlackRock BUIDL, Invesco/Superstate USTB,
+// FRAX sfrxUSD, Liquity V1/V2 Stability Pools, Base Dollar SP, Curve scrvUSD,
+// Reserve USD3, Origin OUSD, Reservoir sr/wsrUSD, Avant savUSD, Noon sUSN,
+// Yuzu syzUSD, dTRINITY sdUSD, Theo thBILL, YO yoUSD — each an issuer-native
+// product rail, none an independent lending venue. Genuine third-party venues
+// (`strategy-vault`, `lending-market`) stay in the denominator and are queued
+// for review via the coverage-audit `venue-risk-config-missing` path.
+const ISSUER_RAIL_DEPLOYMENT_PLACES: Record<string, boolean> = {
+  "native-wrapper": true,
+  "issuer-savings": true,
+};
 const COVERAGE_AUDIT_QUEUE_ACTIONS = ["accept", "dismiss", "intentional-gap", "watch"] satisfies YieldCoverageAuditQueueAction[];
 const COVERAGE_AUDIT_QUEUE_ITEM_KINDS = [
   "manifest-missing",
@@ -294,7 +314,8 @@ function readSourceRiskCoverageRow(
     isBest,
     assetIsVenue:
       ASSET_AS_VENUE_DATA_SOURCES[dataSource] === true
-      || ASSET_AS_VENUE_DATA_SOURCES[deploymentPlace] === true,
+      || ASSET_AS_VENUE_DATA_SOURCES[deploymentPlace] === true
+      || ISSUER_RAIL_DEPLOYMENT_PLACES[deploymentPlace] === true,
     rewardSplitPossible:
       REWARD_SPLIT_CAPABLE_DATA_SOURCES[dataSource] === true || getNumber(row.apyReward) != null,
   };


### PR DESCRIPTION
## Why

Source Risk is degraded on one field: `venueRiskTier` 145/202 eligible rows = 0.718 vs a 0.75 line. I researched all 31 slugs behind those rows with ~90 fetched sources (one per claim, none search-only) and **30 of 31 are the issuer's own rail**, not an independent venue — Sky sUSDS/SSR, Circle/Hashnote USYC, Ethena USDe/sUSDe, Ondo USDY/OUSG, BlackRock BUIDL, Invesco/Superstate USTB, FRAX sfrxUSD, Liquity V1/V2 Stability Pools, Base Dollar SP, Curve scrvUSD, Reserve USD3, Origin OUSD, Reservoir sr/wsrUSD, Avant savUSD, Noon sUSN, Yuzu syzUSD, dTRINITY sdUSD, Theo thBILL, YO yoUSD. Only `current` (a Sui lending venue) is a genuine third-party venue, and it lacked public audit evidence.

I originally recommended researching and adding tier entries. That premise was wrong: you cannot tier a venue that does not exist. The research itself proves the reclassification is correct.

## Change

A row whose venue is the issuer itself cannot carry an independent venue tier, and the coin's Safety Score already prices that risk — counting it made healthy unreachable. Same correction A7 already applied to `price-derived`/`rate-derived`, extended to the two deployment places that mean the same thing: `native-wrapper` (issuer-operated staking/savings wrapper) and `issuer-savings`.

**Measurement only** — no score, penalty, tier, or publication behaviour changes; an unknown tier stays PYS-neutral.

## Effect on the live payload

| field | before | after |
|---|---|---|
| venueRiskTier | 145/202 = 0.718 | **107/121 = 0.884** |
| sourceDepthRatio | 196/202 = 0.970 | 121/121 = 1.0 |
| rewardShare | 111/119 = 0.933 | 63/66 = 0.955 |

Every core field clears the 0.75 line → the tile reads healthy for the right reason. Genuine third-party venues (`strategy-vault`, `lending-market`, 14 rows) stay in the denominator and remain queued via coverage-audit `venue-risk-config-missing` (no guessed tiers).

## Verification

Worker tsc, lint:changed, and the full composite static gate clean. Health suites 36/36, including a new case asserting an issuer rail leaves the tier denominator while a third-party venue stays in it.