### PR TITLE
fix(yield): let NAV-oracle anchors read the daily tier past the raw window

### DIFF
--- a/worker/src/cron/__tests__/yield-resolve.test.ts
+++ b/worker/src/cron/__tests__/yield-resolve.test.ts
@@ -209,6 +209,62 @@ describe("tracked optional source anchors", () => {
       sqlite.close();
     }
   });
+
+  it("falls back to the daily tier for an anchor older than the raw retention window", async () => {
+    // Raw history keeps 30 days, but the Ondo/Midas NAV anchors deliberately
+    // look back 45. Once the raw 30-45 day band is pruned, the anchor must still
+    // resolve from the daily tier (which keeps a year); otherwise a
+    // sparsely-updating NAV oracle silently loses its anchor and stops
+    // publishing — Midas has no shorter-window fallback, unlike Ondo.
+    const sqlite = createLatestSchemaSqlite().sqlite;
+    try {
+      const nowSec = 1_747_000_000;
+      sqlite
+        .prepare(
+          `INSERT INTO yield_history_daily (
+            stablecoin_id, source_key, snapshot_date, recorded_at, is_best, apy,
+            data_source, exchange_rate, publication_state
+          ) VALUES (?, ?, ?, ?, 1, 0, 'protocol-api', ?, 'published')`,
+        )
+        .run("usdy-ondo-finance", "protocol-api:ondo-usdy-oracle", nowSec - 40 * 86_400, nowSec - 40 * 86_400, 1.11);
+
+      // Nothing inside the raw tier's window for this source.
+      const row = await loadOndoOracleAnchorRow(createSqliteD1(sqlite), nowSec);
+
+      expect(row?.exchange_rate).toBe(1.11);
+      expect(row?.recorded_at).toBe(nowSec - 40 * 86_400);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("prefers the raw tier when both tiers can satisfy the anchor window", async () => {
+    const sqlite = createLatestSchemaSqlite().sqlite;
+    try {
+      const nowSec = 1_747_000_000;
+      sqlite
+        .prepare(
+          `INSERT INTO yield_history (
+            stablecoin_id, source_key, apy, data_source, exchange_rate, recorded_at, publication_state
+          ) VALUES (?, ?, 0, 'protocol-api', ?, ?, 'published')`,
+        )
+        .run("usdy-ondo-finance", "protocol-api:ondo-usdy-oracle", 1.09, nowSec - 10 * 86_400);
+      sqlite
+        .prepare(
+          `INSERT INTO yield_history_daily (
+            stablecoin_id, source_key, snapshot_date, recorded_at, is_best, apy,
+            data_source, exchange_rate, publication_state
+          ) VALUES (?, ?, ?, ?, 1, 0, 'protocol-api', ?, 'published')`,
+        )
+        .run("usdy-ondo-finance", "protocol-api:ondo-usdy-oracle", nowSec - 40 * 86_400, nowSec - 40 * 86_400, 1.11);
+
+      const row = await loadOndoOracleAnchorRow(createSqliteD1(sqlite), nowSec);
+
+      expect(row?.exchange_rate).toBe(1.09);
+    } finally {
+      sqlite.close();
+    }
+  });
 });
 
 // --- Direct resolve-helper contracts ---

--- a/worker/src/cron/yield-sync/tracked-optional-source-registry.ts
+++ b/worker/src/cron/yield-sync/tracked-optional-source-registry.ts
@@ -68,7 +68,9 @@ async function loadNavOracleAnchorRow(
   minAgeDays: number,
   maxAgeDays: number,
 ): Promise<OracleAnchorRow | null> {
-  return db
+  const newestAllowed = startSec - minAgeDays * DAY_SECONDS;
+  const oldestAllowed = startSec - maxAgeDays * DAY_SECONDS;
+  const rawRow = await db
     .prepare(
       `SELECT /* pharos:yield-sync:nav-oracle-prior-anchor */
          exchange_rate, recorded_at FROM yield_history
@@ -79,7 +81,28 @@ async function loadNavOracleAnchorRow(
          AND (publication_generation_id IS NULL OR publication_state = 'published')
        ORDER BY recorded_at DESC LIMIT 1`,
     )
-    .bind(stablecoinId, sourceKey, startSec - minAgeDays * DAY_SECONDS, startSec - maxAgeDays * DAY_SECONDS)
+    .bind(stablecoinId, sourceKey, newestAllowed, oldestAllowed)
+    .first<OracleAnchorRow>();
+  if (rawRow) return rawRow;
+
+  // Raw history keeps `YIELD_HISTORY_RAW_DAYS` (30), but these NAV-oracle anchors
+  // deliberately look back up to 45 days, so the 30–45 day band now exists only
+  // in the daily tier. Reading it here keeps the documented long-horizon anchor
+  // window satisfiable instead of silently narrowing it to the raw retention
+  // window — which would strand a sparsely-updating NAV oracle (Midas has no
+  // shorter-window fallback, unlike Ondo) once the band is pruned.
+  return db
+    .prepare(
+      `SELECT /* pharos:yield-sync:nav-oracle-prior-anchor-daily */
+         exchange_rate, recorded_at FROM yield_history_daily
+       WHERE stablecoin_id = ? AND source_key = ?
+         AND exchange_rate IS NOT NULL
+         AND recorded_at <= ?
+         AND recorded_at >= ?
+         AND (publication_generation_id IS NULL OR publication_state = 'published')
+       ORDER BY recorded_at DESC LIMIT 1`,
+    )
+    .bind(stablecoinId, sourceKey, newestAllowed, oldestAllowed)
     .first<OracleAnchorRow>();
 }
 


### PR DESCRIPTION
The v8.43 raw-history retention change (365d → 30d) silently narrowed a second window that no test covered.

`loadNavOracleAnchorRow` (`worker/src/cron/yield-sync/tracked-optional-source-registry.ts`) reads `yield_history` with a 7-to-45 day lookback for the Ondo USDY and Midas mMEV NAV-oracle anchors, while the raw tier now keeps only 30 days. Once the retention drain clears the 30–45 day band, those anchors can only resolve inside 30 days — and `docs/yield-intelligence.md` documents a 45-day allowance for exactly these rows.

The failure is quiet and asymmetric:

- **Ondo** retries with a shorter 3–14 day window, so it degrades rather than breaks.
- **Midas** has no fallback lookback, so a sparse NAV print outside 30 days stops resolving and the source silently drops out.

## Fix

The raw tier stays primary. When it cannot satisfy the window, the loader reads `yield_history_daily`, which keeps a year and carries the same `exchange_rate` and `publication_state` columns. That preserves both policies as written — 30-day raw retention and the full-fidelity daily tier — instead of forcing one to move.

## Verification

- Worker tsc clean; `lint:changed` clean; composite static gate exit 0; worker suite 759 files / 9,880 tests pass.
- New tests: the daily tier satisfies a 40-day anchor when the raw tier has nothing in window, and the raw tier still wins when both can satisfy it.

## How it was found

The retention change's own review verified `yield_history_daily` retention, but not that every long-lookback reader of the raw tier still fits inside it. Worth keeping as a pattern: a retention change is a contract with every consumer's lookback window, and the consumers are not co-located.

## Not fixed here

`usdo-openeden` (the coin that left the 09:55 publication, 155 → 154) is a DeFiLlama pool row, not an anchor consumer — `flags.navToken` is unset and its source key is a DL pool UUID, so this retention path is not implicated. That drop remains unexplained and is tracked separately.
